### PR TITLE
Feature/configurable test properties

### DIFF
--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -19,6 +19,10 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))
 
+  val testProps = getTestProperties
+  val es6TestUrl = testProps.getOrElse("es6.test.url", "http://localhost:9206")
+  val useEsDocker = testProps.getOrElse("es6.useDocker", "true").toBoolean
+
   def esContainer: Option[DockerContainer]
 
   final override def dockerContainers: List[DockerContainer] =

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -1,8 +1,10 @@
 package lib.elasticsearch
 
+import java.io.FileInputStream
 import java.net.URI
 import java.util.UUID
 
+import com.gu.mediaservice.lib.config.Properties.fromStream
 import com.gu.mediaservice.model.usage.{UsageStatus => Status, _}
 import com.gu.mediaservice.model.{StaffPhotographer, _}
 import org.joda.time.DateTime
@@ -125,4 +127,13 @@ trait Fixtures {
     )
   }
 
+  def getTestProperties(): Map[String, String] = {
+    try {
+      fromStream(new FileInputStream(s"/etc/gu/test.properties"))
+    } catch {
+      case e: Exception =>
+        println(s"Exception thrown when trying to create FileInputStream: $e")
+        Map.empty
+    }
+  }
 }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -32,19 +32,19 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
     "persistence.identifier" -> "picdarUrn")))
 
   private val mediaApiMetrics = new MediaApiMetrics(mediaApiConfig)
-  val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = "http://localhost:9206",
+  val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = es6TestUrl,
     cluster = "media-service-test", shards = 1, replicas = 0)
 
   private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig)
   val client = ES.client
 
-  def esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
+  def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9206))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
     )
-  )
+  ) else None
 
   private val expectedNumberOfImages = images.size
 

--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -1,8 +1,10 @@
 package helpers
 
+import java.io.FileInputStream
 import java.net.URI
 import java.util.UUID
 
+import com.gu.mediaservice.lib.config.Properties.fromStream
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.{DigitalUsage, PublishedUsageStatus, Usage}
 import org.joda.time.DateTime
@@ -99,4 +101,13 @@ trait Fixtures {
     out
   }
 
+  def getTestProperties(): Map[String, String] = {
+    try {
+      fromStream(new FileInputStream(s"/etc/gu/test.properties"))
+    } catch {
+      case e: Exception =>
+        println(s"Exception thrown when trying to create FileInputStream: $e")
+        Map.empty
+    }
+  }
 }

--- a/thrall/test/lib/ElasticSearch6Test.scala
+++ b/thrall/test/lib/ElasticSearch6Test.scala
@@ -2,20 +2,19 @@ package lib
 
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.whisk.docker.{DockerContainer, DockerReadyChecker}
-import play.api.Configuration
 
 import scala.concurrent.duration._
 
 class ElasticSearch6Test extends ElasticSearchTestBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "http://localhost:9206", "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", es6TestUrl, "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, None)
-  val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
+  val esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9206))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
     )
-  )
+  ) else None
 }

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -18,6 +18,10 @@ import scala.concurrent.{Await, Future}
 
 trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with Eventually with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
 
+  val testProps = getTestProperties
+  val es6TestUrl = testProps.getOrElse("es6.test.url", "http://localhost:9206")
+  val useEsDocker = testProps.getOrElse("es6.useDocker", "true").toBoolean
+  
   val oneHundredMilliseconds = Duration(100, MILLISECONDS)
   val fiveSeconds = Duration(5, SECONDS)
 

--- a/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
@@ -3,19 +3,19 @@ package syndication
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.whisk.docker.{DockerContainer, DockerReadyChecker}
 import lib._
-import play.api.Configuration
+
 import scala.concurrent.duration._
 
 class SyndicationRightsOpsElastic6Test extends SyndicationRightsOpsTestsBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "http://localhost:9206", "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", es6TestUrl, "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, None)
-  val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
+  val esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9206))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
     )
-  )
+  ) else None
 }

--- a/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
@@ -3,7 +3,6 @@ package syndication
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.whisk.docker.{DockerContainer, DockerReadyChecker}
 import lib._
-
 import scala.concurrent.duration._
 
 class SyndicationRightsOpsElastic6Test extends SyndicationRightsOpsTestsBase {

--- a/thrall/test/syndication/SyndicationRightsOpsTestsBase.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsTestsBase.scala
@@ -18,6 +18,10 @@ import scala.concurrent.duration._
 
 trait SyndicationRightsOpsTestsBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
 
+  val testProps = getTestProperties
+  val es6TestUrl = testProps.getOrElse("es6.test.url", "http://localhost:9206")
+  val useEsDocker = testProps.getOrElse("es6.useDocker", "true").toBoolean
+
   def ES: ElasticSearchVersion
   def esContainer: Option[DockerContainer]
 


### PR DESCRIPTION
## What does this change?
Allows configurable properties for tests in a `etc/gu/test.properties` file 

## How can success be measured?
Locally, create a `etc/gu/test.properties` file with the contents 
```
es6.test.url=http://localhost:9200
use.es.docker=false
```
Then run elasticsearch locally and run the tests for thrall and media api.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
