### PR TITLE
Configurable list of valid emails

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -5,12 +5,13 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.{Request => _, _}
-import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.config.{CommonConfig, ValidEmailsStore}
 import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.action.{AuthActions, UserRequest}
 import com.gu.pandomainauth.model.{AuthenticatedUser, User}
 import com.gu.pandomainauth.service.Google2FAGroupChecker
+import play.api.Logger
 import play.api.libs.ws.{DefaultWSCookie, WSClient, WSCookie}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -37,6 +38,10 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
   val keyStore = new KeyStore(config.authKeyStoreBucket, config)
 
   keyStore.scheduleUpdates(actorSystem.scheduler)
+
+  val validEmailsStore = new ValidEmailsStore(config.permissionsBucket, config)
+
+  validEmailsStore.scheduleUpdates(actorSystem.scheduler)
 
   private val userValidationEmailDomain = config.stringOpt("panda.userDomain").getOrElse("guardian.co.uk")
 
@@ -65,7 +70,14 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
   }
 
   final override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    Authentication.validateUser(authedUser, userValidationEmailDomain, multifactorChecker)
+    val validEmails = validEmailsStore.getValidEmails
+    Authentication.validateUser(authedUser, userValidationEmailDomain, multifactorChecker, validEmails)
+  }
+
+
+  override def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {
+    Logger.info(message)
+    Forbidden("You are not authorised to access The Grid, to get authorisation please email The Grid support team")
   }
 
   def getOnBehalfOfPrincipal(principal: Principal, originalRequest: Request[_]): OnBehalfOfPrincipal = principal match {
@@ -111,10 +123,14 @@ object Authentication {
     case _ => principal.apiKey.name
   }
 
-  def validateUser(authedUser: AuthenticatedUser, userValidationEmailDomain: String, multifactorChecker: Option[Google2FAGroupChecker]): Boolean = {
+  def validateUser(authedUser: AuthenticatedUser, userValidationEmailDomain: String, multifactorChecker: Option[Google2FAGroupChecker], validEmails: Option[List[String]]): Boolean = {
+    val isValidEmail = validEmails match {
+      case Some(emails) => emails.contains(authedUser.user.email)
+      case _ => false
+    }
     val isValidDomain = authedUser.user.email.endsWith("@" + userValidationEmailDomain)
     val passesMultifactor = if(multifactorChecker.nonEmpty) { authedUser.multiFactor } else { true }
 
-    isValidDomain && passesMultifactor
+    isValidEmail && isValidDomain && passesMultifactor
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ValidEmailsStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ValidEmailsStore.scala
@@ -1,0 +1,43 @@
+package com.gu.mediaservice.lib.config
+
+import com.gu.mediaservice.lib.BaseStore
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+class ValidEmailsStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext)
+  extends BaseStore[String, List[String]](bucket, config)(ec) {
+
+  val emailKey = "validEmails"
+  val emailListFileName = "valid_emails.json"
+
+  fetchAll match {
+    case Some(_) => Logger.info("Valid emails read in from config bucket")
+    case None => throw FailedToLoadEmailStore
+  }
+
+  def update() {
+    lastUpdated.send(_ => DateTime.now())
+    fetchAll match {
+      case Some(emailList) => store.send(_ => emailList)
+      case None => Logger.warn("Could not parse valid email list JSON")
+    }
+  }
+
+  private def fetchAll: Option[Map[String, List[String]]] = {
+    getS3Object(emailListFileName) match {
+      case Some(fileContents) => Try(Json.parse(fileContents).as[List[String]]) match {
+        case Success(json) => Some(Map(emailKey -> json))
+        case Failure(_) => None
+      }
+      case None => None
+    }
+  }
+
+  def getValidEmails: Option[List[String]] = store.get().get(emailKey)
+}
+
+case object FailedToLoadEmailStore extends Exception("Failed to load valid emails from S3 permissions bucket on start up")

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/auth/AuthenticationTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/auth/AuthenticationTest.scala
@@ -8,26 +8,32 @@ import org.scalatest.{FunSuite, MustMatchers}
 class AuthenticationTest extends FunSuite with MustMatchers {
   import Authentication.validateUser
 
-  val user = AuthenticatedUser(User("Barry", "Chuckle", "barry.chuckle@guardian.co.uk", None),
+  val email = "barry.chuckle@guardian.co.uk"
+  val emailList =  Some(List(email))
+  val user = AuthenticatedUser(User("Barry", "Chuckle", email, None),
     "media-service", Set("media-service"), Instant.now().plusSeconds(100).toEpochMilli, multiFactor = true)
 
   test("user fails email domain validation") {
-    validateUser(user, "chucklevision.biz", None) must be(false)
+    validateUser(user, "chucklevision.biz", None, emailList) must be(false)
+  }
+
+  test("user fails email validation") {
+    validateUser(user, "guardian.co.uk", None, Some(List("valid.email@guardian.co.uk"))) must be(false)
   }
 
   test("user passes email domain validation") {
-    validateUser(user, "guardian.co.uk", None) must be(true)
+    validateUser(user, "guardian.co.uk", None, emailList) must be(true)
   }
 
   test("user passes mfa check if no mfa checker configured") {
-    validateUser(user.copy(multiFactor = false), "guardian.co.uk", None) must be(true)
+    validateUser(user.copy(multiFactor = false), "guardian.co.uk", None, emailList) must be(true)
   }
 
   test("user fails mfa check if missing mfa") {
-    validateUser(user.copy(multiFactor = false), "guardian.co.uk", Some(null)) must be(false)
+    validateUser(user.copy(multiFactor = false), "guardian.co.uk", Some(null), emailList) must be(false)
   }
 
   test("user passes mfa check") {
-    validateUser(user, "guardian.co.uk", Some(null)) must be(true)
+    validateUser(user, "guardian.co.uk", Some(null), emailList) must be(true)
   }
 }


### PR DESCRIPTION
## What does this change?
Reads in a list of valid emails from s3 and checks wether a user has an allowed email, otherwise gives them an error message. This uses the store pattern (extends BaseStore) which repeatedly reads in the s3 file, allowing updates to the valid email lists with out the need for a redeploy.

## Tested?
- [x] locally
- [ ] on TEST
