### PR TITLE
Extract hardcoded values in MetadataConfig into an s3 file that gets …

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -1,15 +1,16 @@
 package com.gu.mediaservice.lib.cleanup
 
+import com.gu.mediaservice.lib.config.Company
 import com.gu.mediaservice.model.ImageMetadata
 
 trait MetadataCleaner {
   def clean(metadata: ImageMetadata): ImageMetadata
 }
 
-class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
+class MetadataCleaners(companies: List[Company]) {
 
-  val attrCreditFromBylineCleaners = creditBylineMap.map { case (credit, bylines) =>
-    AttributeCreditFromByline(bylines, credit)
+  val attrCreditFromBylineCleaners = companies.map { company =>
+    AttributeCreditFromByline(company.photographers, company.name)
   }
 
   val allCleaners: List[MetadataCleaner] = List(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -1,13 +1,13 @@
 package com.gu.mediaservice.lib.cleanup
 
-import com.gu.mediaservice.model.{NoRights, Agencies, Agency, Image, StaffPhotographer, ContractPhotographer}
-import com.gu.mediaservice.lib.config.PhotographersList
+import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.model._
 
 trait ImageProcessor {
   def apply(image: Image): Image
 }
 
-object SupplierProcessors {
+class SupplierProcessors(metadataConfig: MetadataConfig) {
   val all: List[ImageProcessor] = List(
     GettyXmpParser,
     GettyCreditParser,
@@ -24,17 +24,17 @@ object SupplierProcessors {
     ReutersParser,
     RexParser,
     RonaldGrantParser,
-    PhotographerParser
+    new PhotographerParser(metadataConfig)
   )
 
   def process(image: Image): Image =
     all.foldLeft(image) { case (im, processor) => processor(im) }
 }
 
-object PhotographerParser extends ImageProcessor {
+class PhotographerParser(metadataConfig: MetadataConfig) extends ImageProcessor {
   def apply(image: Image): Image = {
     image.metadata.byline.flatMap { byline =>
-      PhotographersList.getPhotographer(byline).map{
+      metadataConfig.getPhotographer(byline).map {
         case p: StaffPhotographer => image.copy(
           usageRights = p,
           metadata    = image.metadata.copy(credit = Some(p.publication), byline = Some(p.photographer))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -1,32 +1,26 @@
 package com.gu.mediaservice.lib.config
 
-// TODO: Only import the semigroup syntax, but can't find out what to import
-import scalaz._
-import Scalaz._
+import com.gu.mediaservice.model.{ContractPhotographer, Photographer, StaffPhotographer}
+import play.api.libs.json._
 
+case class MetadataConfig(
+  staffIllustrators: List[String],
+  creativeCommonsLicense: List[String],
+  externalStaffPhotographers: List[Company],
+  internalStaffPhotographers: List[Company],
+  contractedPhotographers: List[Company],
+  contractIllustrators: List[Company]) {
+  val staffPhotographers: List[Company] = MetadataConfig.flattenCompanyList(
+    internalStaffPhotographers ++ externalStaffPhotographers)
+  val allPhotographers: List[Company] = MetadataConfig.flattenCompanyList(
+    internalStaffPhotographers ++ externalStaffPhotographers ++ contractedPhotographers)
 
-
-import com.gu.mediaservice.model.{StaffPhotographer, ContractPhotographer, Photographer}
-
-object PhotographersList {
-  type Store = Map[String, String]
-  type CreditBylineMap = Map[String, List[String]]
-
-  import MetadataConfig.{ staffPhotographers, contractedPhotographers }
-
-  def creditBylineMap(store: Store): CreditBylineMap = store
-      .groupBy{ case (photographer, publication) => publication }
-      .map{ case (publication, photographers) => publication -> photographers.keys.toList.sortWith(_.toLowerCase < _.toLowerCase) }
-
-  def creditBylineMap(stores: List[Store]): CreditBylineMap =
-    stores.map(creditBylineMap).reduceLeft(_ |+| _)
-
-  def list(store: Store) = store.keys.toList.sortWith(_.toLowerCase < _.toLowerCase)
-
-  def getPublication(store: Store, name: String): Option[String] = store.get(name)
-
-  def caseInsensitiveLookup(store: Store, lookup: String) =
-    store.find{case (name, pub) => name.toLowerCase == lookup.toLowerCase}
+  def caseInsensitiveLookup(store: List[Company], lookup: String) = {
+    store.map {
+      case Company(name, photographers) if photographers.map(_.toLowerCase) contains lookup.toLowerCase() => Some(lookup, name)
+      case _ => None
+    }.find(_.isDefined).flatten
+  }
 
   def getPhotographer(photographer: String): Option[Photographer] = {
     caseInsensitiveLookup(staffPhotographers, photographer).map {
@@ -37,128 +31,19 @@ object PhotographersList {
   }
 }
 
+case class Company(name: String, photographers: List[String])
+
+object Company {
+  implicit val companyClassFormats = Json.format[Company]
+}
+
 object MetadataConfig {
+  implicit val metadataConfigClassFormats = Json.format[MetadataConfig]
 
-  val externalStaffPhotographers: Map[String, String] = Map(
-    // Current
-    "Ben Doherty"     -> "The Guardian",
-    "Bill Code"       -> "The Guardian",
-    "Calla Wahlquist" -> "The Guardian",
-    "David Sillitoe"  -> "The Guardian",
-    "Graham Turner"   -> "The Guardian",
-    "Helen Davidson"  -> "The Guardian",
-    "Jill Mead"       -> "The Guardian",
-    "Jonny Weeks"     -> "The Guardian",
-    "Joshua Robertson" -> "The Guardian",
-    "Rachel Vere"     -> "The Guardian",
-    "Roger Tooth"     -> "The Guardian",
-    "Sean Smith"      -> "The Guardian",
-    "Melissa Davey"   -> "The Guardian",
-    "Michael Safi"    -> "The Guardian",
-    "Michael Slezak"  -> "The Guardian",
-    "Sean Smith"      -> "The Guardian",
-    "Carly Earl"      -> "The Guardian",
-
-    // Past
-    "Dan Chung"             -> "The Guardian",
-    "Denis Thorpe"          -> "The Guardian",
-    "Don McPhee"            -> "The Guardian",
-    "Frank Baron"           -> "The Guardian",
-    "Frank Martin"          -> "The Guardian",
-    "Garry Weaser"          -> "The Guardian",
-    "Graham Finlayson"      -> "The Guardian",
-    "Martin Argles"         -> "The Guardian",
-    "Peter Johns"           -> "The Guardian",
-    "Robert Smithies"       -> "The Guardian",
-    "Tom Stuttard"          -> "The Guardian",
-    "Tricia De Courcy Ling" -> "The Guardian",
-    "Walter Doughty"        -> "The Guardian",
-    "David Newell Smith"    -> "The Observer",
-    "Tony McGrath"          -> "The Observer",
-    "Catherine Shaw"        -> "The Observer",
-    "John Reardon"          -> "The Observer",
-    "Sean Gibson"           -> "The Observer"
-  )
-
-  // these are people who aren't photographers by trade, but have taken photographs for us.
-  // This is mainly used so when we ingest photos from Picdar, we make sure we categorise
-  // them correctly.
-  // TODO: Think about removin these once Picdar is dead.
-  val internalStaffPhotographers = List(
-    "E Hamilton West"       -> "The Guardian",
-    "Harriet St Johnston"   -> "The Guardian",
-    "Lorna Roach"           -> "The Guardian",
-    "Rachel Vere"           -> "The Guardian",
-    "Ken Saunders"          -> "The Guardian"
-  )
-
-  val staffPhotographers = externalStaffPhotographers ++ internalStaffPhotographers
-
-  val contractedPhotographers: Map[String, String] = Map(
-    "Alicia Canter"       -> "The Guardian",
-    "Antonio Zazueta"     -> "The Guardian",
-    "Christopher Thomond" -> "The Guardian",
-    "David Levene"        -> "The Guardian",
-    "Eamonn McCabe"       -> "The Guardian",
-    "Graeme Robertson"    -> "The Guardian",
-    "Johanna Parkin"      -> "The Guardian",
-    "Linda Nylind"        -> "The Guardian",
-    "Louise Hagger"       -> "The Guardian",
-    "Martin Godwin"       -> "The Guardian",
-    "Mike Bowers"         -> "The Guardian",
-    "Murdo MacLeod"       -> "The Guardian",
-    "Sarah Lee"           -> "The Guardian",
-    "Tom Jenkins"         -> "The Guardian",
-    "Tristram Kenton"     -> "The Guardian",
-    "Jill Mead"           -> "The Guardian",
-
-    "Andy Hall"           -> "The Observer",
-    "Antonio Olmos"       -> "The Observer",
-    "Gary Calton"         -> "The Observer",
-    "Jane Bown"           -> "The Observer",
-    "Jonathan Lovekin"    -> "The Observer",
-    "Karen Robinson"      -> "The Observer",
-    "Katherine Anne Rose" -> "The Observer",
-    "Richard Saker"       -> "The Observer",
-    "Sophia Evans"        -> "The Observer",
-    "Suki Dhanda"         -> "The Observer"
-  )
-
-  val staffIllustrators = List(
-    "Mona Chalabi",
-    "Sam Morris",
-    "Guardian Design"
-  )
-
-  val contractIllustrators: Map[String, String] = Map(
-    "Ben Lamb"              -> "The Guardian",
-    "Andrzej Krauze"        -> "The Guardian",
-    "David Squires"         -> "The Guardian",
-    "First Dog on the Moon" -> "The Guardian",
-    "Harry Venning"         -> "The Guardian",
-    "Martin Rowson"         -> "The Guardian",
-    "Matt Kenyon"           -> "The Guardian",
-    "Matthew Blease"        -> "The Guardian",
-    "Nicola Jennings"       -> "The Guardian",
-    "Rosalind Asquith"      -> "The Guardian",
-    "Steve Bell"            -> "The Guardian",
-    "Steven Appleby"        -> "The Guardian",
-    "Ben Jennings"          -> "The Guardian",
-    "Chris Riddell"         -> "The Observer",
-    "David Foldvari"        -> "The Observer",
-    "David Simonds"         -> "The Observer",
-  )
-
-  val allPhotographers = staffPhotographers ++ contractedPhotographers
-
-  val externalPhotographersMap = PhotographersList.creditBylineMap(externalStaffPhotographers)
-  val staffPhotographersMap = PhotographersList.creditBylineMap(staffPhotographers)
-  val contractPhotographersMap = PhotographersList.creditBylineMap(contractedPhotographers)
-  val allPhotographersMap = PhotographersList.creditBylineMap(allPhotographers)
-  val contractIllustratorsMap = PhotographersList.creditBylineMap(contractIllustrators)
-
-  val creativeCommonsLicense = List(
-    "CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0"
-  )
+  def flattenCompanyList(companies: List[Company]): List[Company] = companies
+    .groupBy(_.name)
+    .map { case (group, companies) => Company(group, companies.flatMap(company => company.photographers)) }
+    .toList
 
 }
+

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataStore.scala
@@ -1,0 +1,54 @@
+package com.gu.mediaservice.lib.config
+
+import com.gu.mediaservice.lib.BaseStore
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+class MetadataStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext)
+  extends BaseStore[String, MetadataConfig](bucket, config)(ec) {
+
+  val metadataMapKey = "metadataConfig"
+  val metadataStoreKey = "photographers.json"
+
+  def apply() = fetchAll match {
+    case Some(_) => Logger.info("Metadata config read in from config bucket")
+    case None => throw FailedToLoadMetadataConfigJson
+  }
+
+  def update() {
+    lastUpdated.send(_ => DateTime.now())
+    fetchAll match {
+      case Some(config) => store.send(_ => config)
+      case None => Logger.warn("Could not parse metadata config JSON into MetadataConfig class")
+    }
+  }
+
+  private def fetchAll: Option[Map[String, MetadataConfig]] = {
+    getS3Object(metadataStoreKey) match {
+      case Some(fileContents) => Try(Json.parse(fileContents).as[MetadataConfig]) match {
+          case Success(metadataConfigClass) => Some(Map(metadataMapKey -> metadataConfigClass))
+          case Failure(_) => None
+        }
+      case None => None
+      }
+    }
+
+  def get: MetadataConfig = store.get()(metadataMapKey)
+}
+
+object MetadataStore {
+  def apply(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext): MetadataStore = {
+    val store = new MetadataStore(bucket, config)(ec)
+    store.fetchAll match {
+      case Some(_) => Logger.info("Metadata config read in from config bucket")
+      case None => throw FailedToLoadMetadataConfigJson
+    }
+    store
+  }
+}
+
+case object FailedToLoadMetadataConfigJson extends Exception("Failed to load metadataConfig from S3 config bucket on start up")

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -1,5 +1,6 @@
 package com.gu.mediaservice.lib.cleanup
 
+import com.gu.mediaservice.lib.config.{Company, MetadataConfig}
 import com.gu.mediaservice.model._
 import org.scalatest.{Matchers, FunSpec}
 
@@ -438,7 +439,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.usageRights should be(Agency("Ronald Grant Archive"))
       processedImage.metadata.credit should be(Some("Ronald Grant"))
     }
-    
+
     it("should match Ronald Grant Archive credit") {
       val image = createImageFromMetadata("credit" -> "Ronald Grant Archive")
       val processedImage = applyProcessors(image)
@@ -455,7 +456,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.usageRights should be(Agency("Bloomberg"))
       processedImage.metadata.credit should be(Some("Bloomberg"))
     }
-    
+
     it("should detect Bloomberg via Getty as Getty with suppliersCollection Bloomberg and not as Bloomberg") {
       val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
       val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "atari.jpg")))
@@ -467,8 +468,14 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   }
 
 
-  def applyProcessors(image: Image): Image =
-    SupplierProcessors.process(image)
-
-
+  def applyProcessors(image: Image): Image = {
+    val metadataConfig =
+      MetadataConfig(List(), List(),
+        List(Company("The Guardian", List("Graham Turner"))),
+        List(),
+        List(Company("The Guardian", List("Linda Nylind", "Murdo MacLeod"))),
+        List()
+      )
+    new SupplierProcessors(metadataConfig).process(image)
+  }
 }

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -1,14 +1,11 @@
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.imaging.ImageOperations
-import com.gu.mediaservice.lib.play.{GridComponents, RequestLoggingFilter}
+import com.gu.mediaservice.lib.play.GridComponents
 import controllers.ImageLoaderController
 import lib._
 import lib.storage.ImageLoaderStore
 import model.{ImageUploadOps, OptimisedPngOps}
 import play.api.ApplicationLoader.Context
-import play.api.mvc.EssentialFilter
-import play.filters.HttpFiltersComponents
-import play.filters.cors.CORSComponents
-import play.filters.gzip.GzipFilterComponents
 import router.Routes
 
 class ImageLoaderComponents(context: Context) extends GridComponents(context) {
@@ -16,15 +13,19 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context) {
 
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val store = new ImageLoaderStore(config)
+  val loaderStore = new ImageLoaderStore(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val notifications = new Notifications(config)
   val downloader = new Downloader()
-  val optimisedPngOps = new OptimisedPngOps(store, config)
-  val imageUploadOps = new ImageUploadOps(store, config, imageOperations, optimisedPngOps)
+  val optimisedPngOps = new OptimisedPngOps(loaderStore, config)
 
-  val controller = new ImageLoaderController(auth, downloader, store, notifications, config, imageUploadOps, controllerComponents, wsClient)
+  val metaDataConfigStore = MetadataStore(config.configBucket, config)
+  metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
+
+  val imageUploadOps = new ImageUploadOps(metaDataConfigStore, loaderStore, config, imageOperations, optimisedPngOps)
+
+  val controller = new ImageLoaderController(auth, downloader, loaderStore, notifications, config, imageUploadOps, controllerComponents, wsClient)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management)
 }

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -13,6 +13,8 @@ class ImageLoaderConfig(override val configuration: Configuration) extends Commo
 
   val thumbnailBucket: String = properties("s3.thumb.bucket")
 
+  val configBucket: String = properties("s3.config.bucket")
+
   val tempDir: File = new File(properties.getOrElse("upload.tmp.dir", "/tmp"))
 
   val thumbWidth: Int = 256

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.gu.mediaservice.lib.aws.S3Object
 import com.gu.mediaservice.lib.cleanup.{MetadataCleaners, SupplierProcessors}
-import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.formatting._
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.metadata.{FileMetadataHelper, ImageMetadataConverter}
@@ -69,7 +69,6 @@ class OptimisedPngOps(store: ImageLoaderStore, config: ImageLoaderConfig)(implic
 
 case class ImageUpload(uploadRequest: UploadRequest, image: Image)
 case object ImageUpload {
-  val metadataCleaners = new MetadataCleaners(MetadataConfig.allPhotographersMap)
 
   def createImage(uploadRequest: UploadRequest, source: Asset, thumbnail: Asset, png: Option[Asset],
                   fileMetadata: FileMetadata, metadata: ImageMetadata): Image = {
@@ -96,7 +95,11 @@ case object ImageUpload {
   }
 }
 
-class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOps: ImageOperations, optimisedPngOps: OptimisedPngOps)(implicit val ec: ExecutionContext) {
+class ImageUploadOps(metadataStore: MetadataStore,
+                     loaderStore: ImageLoaderStore,
+                     config: ImageLoaderConfig,
+                     imageOps: ImageOperations,
+                     optimisedPngOps: OptimisedPngOps)(implicit val ec: ExecutionContext) {
   def fromUploadRequest(uploadRequest: UploadRequest): Future[ImageUpload] = {
 
     val uploadedFile = uploadRequest.tempFile
@@ -157,8 +160,10 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
           colourModel <- colourModelFuture
           fullFileMetadata = fileMetadata.copy(colourModel = colourModel)
 
+          metaDataConfig = metadataStore.get
+          metadataCleaners = new MetadataCleaners(metaDataConfig.allPhotographers)
           metadata = ImageMetadataConverter.fromFileMetadata(fullFileMetadata)
-          cleanMetadata = ImageUpload.metadataCleaners.clean(metadata)
+          cleanMetadata = metadataCleaners.clean(metadata)
 
           sourceAsset = Asset.fromS3Object(s3Source, sourceDimensions)
           thumbAsset = Asset.fromS3Object(s3Thumb, thumbDimensions)
@@ -169,7 +174,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
             None
 
           baseImage = ImageUpload.createImage(uploadRequest, sourceAsset, thumbAsset, pngAsset, fullFileMetadata, cleanMetadata)
-          processedImage = SupplierProcessors.process(baseImage)
+          processedImage = new SupplierProcessors(metaDataConfig).process(baseImage)
 
           // FIXME: dirty hack to sync the originalUsageRights and originalMetadata as well
           finalImage = processedImage.copy(
@@ -187,7 +192,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
     })
   }
 
-  def storeSource(uploadRequest: UploadRequest) = store.storeOriginal(
+  def storeSource(uploadRequest: UploadRequest) = loaderStore.storeOriginal(
     uploadRequest.id,
     uploadRequest.tempFile,
     uploadRequest.mimeType,
@@ -196,7 +201,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
       "upload_time" -> printDateTime(uploadRequest.uploadTime)
     ) ++ uploadRequest.identifiersMeta
   )
-  def storeThumbnail(uploadRequest: UploadRequest, thumbFile: File) = store.storeThumbnail(
+  def storeThumbnail(uploadRequest: UploadRequest, thumbFile: File) = loaderStore.storeThumbnail(
     uploadRequest.id,
     thumbFile,
     Some("image/jpeg")

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.management.ManagementWithPermissions
@@ -37,7 +38,10 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
+  val metaDataConfigStore = MetadataStore(config.configBucket, config)
+  metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
+
+  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, metaDataConfigStore)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -2,7 +2,6 @@ package lib
 
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.gu.mediaservice.lib.config.CommonConfig
-import com.gu.mediaservice.lib.discovery.EC2._
 import org.joda.time.DateTime
 import play.api.Configuration
 

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{EditsApi, EditsController}
@@ -22,8 +23,12 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context)
     () => messageConsumer.actorSystem.terminate()
   }
 
+  val metaDataConfigStore = new MetadataStore(config.configBucket, config)
+  metaDataConfigStore()
+  metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
+
   val editsController = new EditsController(auth, store, notifications, config, controllerComponents)
-  val controller = new EditsApi(auth, config, controllerComponents)
+  val controller = new EditsApi(auth, config, controllerComponents, metaDataConfigStore)
 
   override val router = new Routes(httpErrorHandler, controller, editsController, management)
 }

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -3,6 +3,7 @@ package controllers
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.config.{MetadataConfig, MetadataStore}
 import com.gu.mediaservice.model._
 import lib.EditsConfig
 import model.UsageRightsProperty
@@ -12,7 +13,8 @@ import play.api.mvc.{BaseController, ControllerComponents}
 import scala.concurrent.ExecutionContext
 
 class EditsApi(auth: Authentication, config: EditsConfig,
-               override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
+               override val controllerComponents: ControllerComponents,
+               metadataStore: MetadataStore)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
 
@@ -32,10 +34,12 @@ class EditsApi(auth: Authentication, config: EditsConfig,
 
   def index = auth { indexResponse }
 
-  val usageRightsResponse = {
-    val usageRightsData = UsageRights.all.map(CategoryResponse.fromUsageRights)
 
-    respond(usageRightsData)
+  def usageRightsResponse = {
+      val metadataConfig = metadataStore.get
+      val usageRightsData = UsageRights.all.map(u => CategoryResponse.fromUsageRights(u, metadataConfig))
+
+      respond(usageRightsData)
   }
 
   def getUsageRights = auth { usageRightsResponse }
@@ -53,7 +57,7 @@ case class CategoryResponse(
 object CategoryResponse {
   // I'd like to have an override of the `apply`, but who knows how you do that
   // with the JSON parsing stuff
-  def fromUsageRights(u: UsageRightsSpec): CategoryResponse =
+  def fromUsageRights(u: UsageRightsSpec, m: MetadataConfig): CategoryResponse =
     CategoryResponse(
       value               = u.category,
       name                = u.name,
@@ -61,7 +65,7 @@ object CategoryResponse {
       description         = u.description,
       defaultRestrictions = u.defaultRestrictions,
       caution             = u.caution,
-      properties          = UsageRightsProperty.getPropertiesForSpec(u)
+      properties          = UsageRightsProperty.getPropertiesForSpec(u, m)
     )
 
   implicit val categoryResponseWrites: Writes[CategoryResponse] = Json.writes[CategoryResponse]

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -13,6 +13,7 @@ class EditsConfig(override val configuration: Configuration) extends CommonConfi
 
   val keyStoreBucket = properties("auth.keystore.bucket")
   val collectionsBucket: String = properties("s3.collections.bucket")
+  val configBucket: String = properties("s3.config.bucket")
 
   val editsTable = properties("dynamo.table.edits")
 

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -1,8 +1,8 @@
 package model
 
-import play.api.libs.json._
-import com.gu.mediaservice.lib.config.{MetadataConfig, UsageRightsConfig}
+import com.gu.mediaservice.lib.config.{Company, MetadataConfig, UsageRightsConfig}
 import com.gu.mediaservice.model._
+import play.api.libs.json._
 
 
 // TODO: We'll be able to deprecate this and build it up directly from case
@@ -19,22 +19,25 @@ case class UsageRightsProperty(
   examples: Option[String] = None
 )
 
-
 object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import MetadataConfig.{contractPhotographersMap, staffPhotographersMap, contractIllustratorsMap, staffIllustrators, creativeCommonsLicense}
   import UsageRightsConfig.freeSuppliers
 
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
 
   def sortList(l: List[String]) = l.sortWith(_.toLowerCase < _.toLowerCase)
 
-  val props: List[(UsageRightsSpec) => List[UsageRightsProperty]] =
+  val props: List[(UsageRightsSpec, MetadataConfig) => List[UsageRightsProperty]] =
     List(categoryUsageRightsProperties, restrictionProperties)
 
-  def getPropertiesForSpec(u: UsageRightsSpec): List[UsageRightsProperty] = props.flatMap(f => f(u))
+  def companyListToMap(companies: List[Company]): OptionsMap = Map(companies
+    .map(c => c.name -> c.photographers): _*)
+
+  def optionsFromCompanyList(companies: List[Company]): Options = sortList(companyListToMap(companies).keys.toList)
+
+  def getPropertiesForSpec(u: UsageRightsSpec, m: MetadataConfig): List[UsageRightsProperty] = props.flatMap(f => f(u, m))
 
   private def requiredStringField(
     name: String,
@@ -46,27 +49,26 @@ object UsageRightsProperty {
   ) = UsageRightsProperty(name, label, "string", required = true, options,
                           optionsMap, optionsMapKey, examples)
 
-  private def publicationField(required: Boolean)  =
-    UsageRightsProperty("publication", "Publication", "string", required,
-      Some(sortList(staffPhotographersMap.keys.toList)))
+  private def publicationField(required: Boolean, options: Options)  =
+    UsageRightsProperty("publication", "Publication", "string", required, Some(options))
 
   private def photographerField(examples: String) =
     requiredStringField("photographer", "Photographer", examples = Some(examples))
 
-  private def photographerField(photographers: OptionsMap, key: String) =
+  private def photographerField(photographers: List[Company], key: String) =
     requiredStringField("photographer", "Photographer",
-      optionsMap = Some(photographers), optionsMapKey = Some(key))
+      optionsMap = Some(companyListToMap(photographers)), optionsMapKey = Some(key))
 
-  private def illustratorField(illustrators: OptionsMap, key: String) =
+  private def illustratorField(illustrators: List[Company], key: String) =
     requiredStringField("creator", "Illustrator",
-      optionsMap = Some(illustrators), optionsMapKey = Some(key))
+      optionsMap = Some(companyListToMap(illustrators)), optionsMapKey = Some(key))
 
-  private def restrictionProperties(u: UsageRightsSpec): List[UsageRightsProperty] = u match {
+  private def restrictionProperties(u: UsageRightsSpec, m: MetadataConfig): List[UsageRightsProperty] = u match {
     case NoRights => List()
     case _ => List(UsageRightsProperty("restrictions", "Restrictions", "text", u.defaultCost.contains(Conditional)))
   }
 
-  def categoryUsageRightsProperties(u: UsageRightsSpec) = u match {
+  def categoryUsageRightsProperties(u: UsageRightsSpec, m: MetadataConfig) = u match {
     case Agency => List(
       requiredStringField("supplier", "Supplier", Some(sortList(freeSuppliers))),
       UsageRightsProperty(
@@ -77,34 +79,34 @@ object UsageRightsProperty {
     case CommissionedAgency => List(requiredStringField("supplier", "Supplier", examples = Some("Demotix")))
 
     case StaffPhotographer => List(
-      publicationField(true),
-      photographerField(staffPhotographersMap, "publication")
+      publicationField(true, optionsFromCompanyList(m.staffPhotographers)),
+      photographerField(m.staffPhotographers, "publication")
     )
 
     case ContractPhotographer => List(
-      publicationField(true),
-      photographerField(contractPhotographersMap, "publication")
+      publicationField(true, optionsFromCompanyList(m.contractedPhotographers)),
+      photographerField(m.contractedPhotographers, "publication")
     )
 
     case CommissionedPhotographer => List(
-      publicationField(false),
+      publicationField(false, optionsFromCompanyList(m.staffPhotographers)),
       photographerField("Sophia Evans, Murdo MacLeod")
     )
 
     case ContractIllustrator => List(
-      publicationField(true),
-      illustratorField(contractIllustratorsMap, "publication")
+      publicationField(true, optionsFromCompanyList(m.contractIllustrators)),
+      illustratorField(m.contractIllustrators, "publication")
     )
 
     case StaffIllustrator => List(
-      requiredStringField("creator", "Illustrator", Some(sortList(staffIllustrators))))
+      requiredStringField("creator", "Illustrator", Some(sortList(m.staffIllustrators))))
 
     case CommissionedIllustrator => List(
-      publicationField(false),
+      publicationField(false, optionsFromCompanyList(m.staffPhotographers)),
       requiredStringField("creator", "Illustrator", examples = Some("Ellie Foreman Peck, Matt Bors")))
 
     case CreativeCommons => List(
-      requiredStringField("licence", "Licence", Some(creativeCommonsLicense)),
+      requiredStringField("licence", "Licence", Some(m.creativeCommonsLicense)),
       requiredStringField("source", "Source", examples = Some("Wikimedia Commons")),
       requiredStringField("creator", "Owner", examples = Some("User:Colin")),
       requiredStringField("contentLink", "Link to content", examples = Some("https://commons.wikimedia.org/wiki/File:Foreign_and_Commonwealth_Office_-_Durbar_Court.jpg"))

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -40,6 +40,7 @@ function getImageLoaderConfig(config) {
     return stripMargin`
         |domain.root=${config.domainRoot}
         |aws.region=${config.aws.region}
+        |s3.config.bucket=${config.stackProps.ConfigBucket}
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
@@ -99,6 +100,7 @@ function getMetadataEditorConfig(config) {
     return stripMargin`
         |domain.root=${config.domainRoot}
         |aws.region=${config.aws.region}
+        |s3.config.bucket=${config.stackProps.ConfigBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.collections.bucket=${config.stackProps.CollectionsBucket}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}


### PR DESCRIPTION
## What does this change?
This removes all hard coded photographers names in MetaDataConfig. Instead these are now read from an s3 file into MetaDataStore and parsed as a MetadataConfig class. This allows updates to these lists to be made without the need for a redeploy.

If the json cannot be parsed on startup an error is thrown which stops the app. But after intial load if subsequent parsing fails (if someone makes the json file invalid) only a warning is logged and the last successful load is kept in the store.

The `s3.config.bucket` is where the json should be held, I have sent the guardian's version of this to @akash1810.

## How can success be measured?
Put the json file in the `s3.config.bucket` with the name of `photographers.json`
Add the bucket name to your `/etc/gu` properties for image-loader, api and metadata-editor: `s3.config.bucket=<bucket name>`. 

Updating the json config in `s3.config.bucket` will make the photographers names update (after 10 mins). 

## Tested?
- [x] locally
- [ ] on TEST
