### PR TITLE
Configurable matches on credit or source for each supplier

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -1,10 +1,23 @@
 package com.gu.mediaservice.lib.cleanup
 
-import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.lib.config.{MetadataConfig, SupplierMatch, UsageRightsConfig}
 import com.gu.mediaservice.model._
 
 trait ImageProcessor {
-  def apply(image: Image): Image
+  def apply(image: Image, supplierCreditMatches: List[SupplierMatch]): Image
+
+  def getMatcher(parserName: String, matches: List[SupplierMatch]): Option[SupplierMatch] =
+    matches.find(m => m.name == parserName)
+
+  def matchesCreditOrSource(image: Image, parserName: String, supplierMatches: List[SupplierMatch])=
+    getMatcher(parserName, supplierMatches) match {
+      case Some(m) => (image.metadata.credit, image.metadata.source) match {
+        case (Some(credit), _) if m.creditMatches.map(_.toLowerCase).exists(credit.toLowerCase.matches) => true
+        case (_, Some(source)) if m.sourceMatches.map(_.toLowerCase).exists(source.toLowerCase.matches) => true
+        case _ => false
+      }
+      case _ => false
+    }
 }
 
 class SupplierProcessors(metadataConfig: MetadataConfig) {
@@ -27,11 +40,13 @@ class SupplierProcessors(metadataConfig: MetadataConfig) {
     new PhotographerParser(metadataConfig)
   )
 
-  def process(image: Image): Image =
-    all.foldLeft(image) { case (im, processor) => processor(im) }
+  def process(image: Image, c: UsageRightsConfig): Image =
+    all.foldLeft(image) { case (im, processor) => processor(im, c.supplierCreditMatches) }
 }
 
 class PhotographerParser(metadataConfig: MetadataConfig) extends ImageProcessor {
+
+  def apply(image: Image, matches: List[SupplierMatch]): Image = apply(image)
   def apply(image: Image): Image = {
     image.metadata.byline.flatMap { byline =>
       metadataConfig.getPhotographer(byline).map {
@@ -46,47 +61,50 @@ class PhotographerParser(metadataConfig: MetadataConfig) extends ImageProcessor 
         case _ => image
       }
     }
-  }.getOrElse(image)
+    }.getOrElse(image)
 }
 
 object AapParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("AAPIMAGE") | Some("AAP IMAGE") | Some("AAP") => image.copy(
-      usageRights = Agencies.get("aap"),
-      metadata    = image.metadata.copy(credit = Some("AAP"))
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "AapParser", matches))
+      image.copy(
+        usageRights = Agencies.get("aap"),
+        metadata    = image.metadata.copy(credit = Some("AAP"))
+      )
+    else image
 }
 
 object ActionImagesParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Action Images") | Some("Action Images via Reuters") => image.copy(
-      usageRights = Agency("Action Images")
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "ActionImagesParser", matches))
+      image.copy(
+        usageRights = Agency("Action Images")
+      )
+    else image
 }
 
 object AlamyParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Alamy") | Some("Alamy Stock Photo") => image.copy(
-      usageRights = Agencies.get("alamy")
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "AlamyParser", matches))
+      image.copy(
+        usageRights = Agencies.get("alamy")
+      )
+    else image
 }
 
 object AllStarParser extends ImageProcessor {
   val SlashAllstar = """(.+)/Allstar""".r
   val AllstarSlash = """Allstar/(.+)""".r
 
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Allstar Picture Library") => withAllstarRights(image)(None)
-    case Some(SlashAllstar(prefix))      => withAllstarRights(image)(Some(prefix))
-    case Some(AllstarSlash(suffix))      => withAllstarRights(image)(Some(suffix))
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "AllStarParser", matches))
+      withAllstarRights(image)(None)
+    else image.metadata.credit match {
+      case Some(SlashAllstar(prefix))      => withAllstarRights(image)(Some(prefix))
+      case Some(AllstarSlash(suffix))      => withAllstarRights(image)(Some(suffix))
+      case _ => image
+    }
+
 
   def withAllstarRights(image: Image) =
     (asAllstarAgency(image, _: Option[String])) andThen
@@ -127,52 +145,53 @@ object ApParser extends ImageProcessor {
   val InvisionFor = "^invision for (.+)".r
   val PersonInvisionAp = "(.+)\\s*/invision/ap$".r
 
-  def apply(image: Image): Image = image.metadata.credit.map(_.toLowerCase) match {
-    case Some("ap") | Some("associated press") => image.copy(
-      usageRights = Agency("AP"),
-      metadata    = image.metadata.copy(credit = Some("AP"))
-    )
-    case Some("invision") | Some("invision/ap") |
-         Some(InvisionFor(_)) | Some(PersonInvisionAp(_)) => image.copy(
-      usageRights = Agency("AP", Some("Invision"))
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "ApParser", matches))
+      image.copy(
+        usageRights = Agency("AP"),
+        metadata    = image.metadata.copy(credit = Some("AP"))
+      )
+    else image.metadata.credit.map(_.toLowerCase) match {
+      case Some("invision") | Some("invision/ap") |
+           Some(InvisionFor(_)) | Some(PersonInvisionAp(_)) => image.copy(
+        usageRights = Agency("AP", Some("Invision"))
+      )
+      case _ => image
+    }
 }
 
 object BarcroftParser extends ImageProcessor {
-  def apply(image: Image): Image =
-    // We search the credit and the source here as Barcroft seems to use both
-    if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
-      List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
-    }) image.copy(usageRights = Agency("Barcroft Media")) else image
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "BarcroftParser", matches))
+      image.copy(usageRights = Agency("Barcroft Media"))
+    else image
 }
 
 object BloombergParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Bloomberg") => image.copy(
-      usageRights = Agencies.get("bloomberg")
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "BloombergParser", matches))
+      image.copy(
+        usageRights = Agencies.get("bloomberg")
+      )
+    else image
 }
 
 object CorbisParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.source match {
-    case Some("Corbis") => image.copy(
-      usageRights = Agency("Corbis")
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "CorbisParser", matches))
+      image.copy(
+        usageRights = Agency("Corbis")
+      )
+    else image
 }
 
 object EpaParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some(x) if x.matches(".*\\bEPA\\b.*") => image.copy(
-      usageRights = Agency("EPA")
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "EpaParser", matches))
+      image.copy(
+        usageRights = Agency("EPA")
+      )
+    else image
 }
 
 trait GettyProcessor {
@@ -182,7 +201,7 @@ trait GettyProcessor {
 }
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
-  def apply(image: Image): Image = {
+  def apply(image: Image, matches: List[SupplierMatch]): Image = {
     val excludedCredit = List(
       "Replay Images", "newspix international", "i-images", "photoshot", "Ian Jones", "Photo News/Panoramic",
       "Panoramic/Avalon", "Panoramic", "Avalon", "INS News Agency Ltd", "Discovery.", "EPA", "EMPICS", "Empics News",
@@ -219,18 +238,15 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
 object GettyCreditParser extends ImageProcessor with GettyProcessor {
   val gettyCredits = List("AFP", "FilmMagic", "WireImage", "Hulton")
 
-  val IncludesGetty = ".*Getty Images.*".r
-  // Take a leap of faith as the credit may be truncated if too long...
-  val ViaGetty = ".+ via Getty(?: .*)?".r
-  val SlashGetty = ".+/Getty(?: .*)?".r
-
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some(IncludesGetty()) | Some(ViaGetty()) | Some(SlashGetty()) => image.copy(
-       usageRights = gettyAgencyWithCollection(image.metadata.source)
-    )
-    case Some(credit) => knownGettyCredits(image, credit)
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "GettyCreditParser", matches))
+      image.copy(
+        usageRights = gettyAgencyWithCollection(image.metadata.source)
+      )
+    else image.metadata.credit match {
+      case Some(credit) => knownGettyCredits(image, credit)
+      case _ => image
+    }
 
   def knownGettyCredits(image: Image, credit: String): Image =
     gettyCredits.find(_.toLowerCase == credit.toLowerCase) match {
@@ -242,68 +258,53 @@ object GettyCreditParser extends ImageProcessor with GettyProcessor {
 }
 
 object PaParser extends ImageProcessor {
-  val paCredits = List(
-    "PA",
-    "PA WIRE",
-    "PA Wire/PA Images",
-    "PA Wire/PA Photos",
-    "PA Wire/Press Association Images",
-    "PA Archive/PA Photos",
-    "PA Archive/PA Images",
-    "PA Archive/Press Association Ima",
-    "PA Archive/Press Association Images",
-    "Press Association Images"
-  ).map(_.toLowerCase)
-
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some(credit) if paCredits.contains(credit.toLowerCase) => image.copy(
-      metadata = image.metadata.copy(credit = Some("PA")),
-      usageRights = Agency("PA")
-    )
-
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "PaParser", matches))
+      image.copy(
+        metadata = image.metadata.copy(credit = Some("PA")),
+        usageRights = Agency("PA")
+      )
+    else image
 }
 
 object ReutersParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    // Reuters and other misspellings
-    // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") => image.copy(
-      usageRights = Agency("Reuters"),
-      metadata = image.metadata.copy(credit = Some("Reuters"))
-    )
-    // Others via Reuters
-    case Some("USA TODAY Sports") => image.copy(
-      metadata = image.metadata.copy(credit = Some("USA Today Sports")),
-      usageRights = Agency("Reuters")
-    )
-    case Some("USA Today Sports") | Some("TT NEWS AGENCY") => image.copy(
-      usageRights = Agency("Reuters")
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+  // Reuters and other misspellings
+  // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
+    if (matchesCreditOrSource(image, "ReutersParser", matches))
+      image.copy(
+        usageRights = Agency("Reuters"),
+        metadata = image.metadata.copy(credit = Some("Reuters"))
+      )
+    else image.metadata.credit match {
+      // Others via Reuters
+      case Some("USA TODAY Sports") => image.copy(
+        metadata = image.metadata.copy(credit = Some("USA Today Sports")),
+        usageRights = Agency("Reuters")
+      )
+      case Some("USA Today Sports") | Some("TT NEWS AGENCY") => image.copy(
+        usageRights = Agency("Reuters")
+      )
+      case _ => image
+    }
 }
 
 object RexParser extends ImageProcessor {
   val rexAgency = Agencies.get("rex")
   val SlashRex = ".+/ Rex Features".r
 
-  def apply(image: Image): Image = (image.metadata.source, image.metadata.credit) match {
-    // TODO: cleanup byline/credit
-    case (Some("Rex Features"), _)      => image.copy(usageRights = rexAgency)
-    case (_, Some(SlashRex()))          => image.copy(usageRights = rexAgency)
-    case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = rexAgency)
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "RexParser", matches))
+      image.copy(usageRights = rexAgency)
+    else image
 }
 
 object RonaldGrantParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("www.ronaldgrantarchive.com") | Some("Ronald Grant Archive") => image.copy(
-      usageRights = Agency("Ronald Grant Archive"),
-      metadata    = image.metadata.copy(credit = Some("Ronald Grant"))
-    )
-    case _ => image
-  }
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "RonaldGrantParser", matches))
+      image.copy(
+        usageRights = Agency("Ronald Grant Archive"),
+        metadata = image.metadata.copy(credit = Some("Ronald Grant"))
+      )
+    else image
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -2,12 +2,22 @@ package com.gu.mediaservice.lib.config
 
 import play.api.libs.json._
 
-case class UsageRightsConfig(usageRights: List[String], freeSuppliers: List[String], suppliersCollectionExcl: Map[String, List[String]]) {
+case class UsageRightsConfig(
+                              supplierCreditMatches: List[SupplierMatch],
+                              usageRights: List[String],
+                              freeSuppliers: List[String],
+                              suppliersCollectionExcl: Map[String, List[String]]) {
 
   def isFreeSupplier(supplier: String) = freeSuppliers.contains(supplier)
 
   def isExcludedColl(supplier: String, supplierColl: String) =
     suppliersCollectionExcl.get(supplier).exists(_.contains(supplierColl))
+}
+
+case class SupplierMatch(name: String, creditMatches: List[String], sourceMatches: List[String])
+
+object SupplierMatch {
+  implicit val supplierMatchesFormats = Json.format[SupplierMatch]
 }
 
 object UsageRightsConfig {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -469,6 +469,28 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
 
 
   def applyProcessors(image: Image): Image = {
+
+    val matches: List[SupplierMatch] =
+      List(
+        SupplierMatch("GettyXmpParser", List(), List()),
+        SupplierMatch("GettyCreditParser", List(".*Getty Images.*", ".+ via Getty(?: .*)?", ".+/Getty(?: .*)?"), List()),
+        SupplierMatch("AapParser", List("AAPIMAGE", "AAP IMAGE", "AAP"), List()),
+        SupplierMatch("ActionImagesParser", List("Action Images", "Action Images via Reuters"), List()),
+        SupplierMatch("AlamyParser", List("Alamy", "Alamy Stock Photo"), List()),
+        SupplierMatch("AllStarParser", List("Allstar Picture Library"), List()),
+        SupplierMatch("ApParser", List("ap", "associated press"), List()),
+        SupplierMatch("BarcroftParser", List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"), List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars")),
+        SupplierMatch("BloombergParser", List("Bloomberg"), List()),
+        SupplierMatch("CorbisParser", List(), List("Corbis")),
+        SupplierMatch("EpaParser", List(".*\\bEPA\\b.*"), List()),
+        SupplierMatch("PaParser", List("PA", "PA WIRE", "PA Wire/PA Images", "PA Wire/PA Photos", "PA Wire/Press Association Images", "PA Archive/PA Photos", "PA Archive/PA Images", "PA Archive/Press Association Ima", "PA Archive/Press Association Images", "Press Association Images"), List()),
+        SupplierMatch("ReutersParser", List("REUTERS", "Reuters", "RETUERS", "REUTERS/"), List()),
+        SupplierMatch("RexParser", List(".+/ Rex Features"), List("Rex Features", "REX/Shutterstock")),
+        SupplierMatch("RonaldGrantParser", List("www.ronaldgrantarchive.com", "Ronald Grant Archive"), List())
+      )
+    val usageRightsConfig =
+      UsageRightsConfig(matches, List(), List(), Map())
+
     val metadataConfig =
       MetadataConfig(List(), List(),
         List(Company("The Guardian", List("Graham Turner"))),
@@ -476,6 +498,6 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
         List(Company("The Guardian", List("Linda Nylind", "Murdo MacLeod"))),
         List()
       )
-    new SupplierProcessors(metadataConfig).process(image)
+    new SupplierProcessors(metadataConfig).process(image, usageRightsConfig)
   }
 }

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -1,4 +1,4 @@
-import com.gu.mediaservice.lib.config.MetadataStore
+import com.gu.mediaservice.lib.config.{MetadataStore, UsageRightsStore}
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.ImageLoaderController
@@ -23,7 +23,10 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context) {
   val metaDataConfigStore = MetadataStore(config.configBucket, config)
   metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
 
-  val imageUploadOps = new ImageUploadOps(metaDataConfigStore, loaderStore, config, imageOperations, optimisedPngOps)
+  val usageRightsConfigStore = UsageRightsStore(config.configBucket, config)
+  usageRightsConfigStore.scheduleUpdates(actorSystem.scheduler)
+
+  val imageUploadOps = new ImageUploadOps(metaDataConfigStore, usageRightsConfigStore, loaderStore, config, imageOperations, optimisedPngOps)
 
   val controller = new ImageLoaderController(auth, downloader, loaderStore, notifications, config, imageUploadOps, controllerComponents, wsClient)
 

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.gu.mediaservice.lib.aws.S3Object
 import com.gu.mediaservice.lib.cleanup.{MetadataCleaners, SupplierProcessors}
-import com.gu.mediaservice.lib.config.MetadataStore
+import com.gu.mediaservice.lib.config.{MetadataStore, UsageRightsStore}
 import com.gu.mediaservice.lib.formatting._
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.metadata.{FileMetadataHelper, ImageMetadataConverter}
@@ -96,6 +96,7 @@ case object ImageUpload {
 }
 
 class ImageUploadOps(metadataStore: MetadataStore,
+                     usageRightsStore: UsageRightsStore,
                      loaderStore: ImageLoaderStore,
                      config: ImageLoaderConfig,
                      imageOps: ImageOperations,
@@ -173,8 +174,10 @@ class ImageUploadOps(metadataStore: MetadataStore,
           else
             None
 
+          usageRightsConfig = usageRightsStore.get
+
           baseImage = ImageUpload.createImage(uploadRequest, sourceAsset, thumbAsset, pngAsset, fullFileMetadata, cleanMetadata)
-          processedImage = new SupplierProcessors(metaDataConfig).process(baseImage)
+          processedImage = new SupplierProcessors(metaDataConfig).process(baseImage, usageRightsConfig)
 
           // FIXME: dirty hack to sync the originalUsageRights and originalMetadata as well
           finalImage = processedImage.copy(

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -45,7 +45,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val metaDataConfigStore = MetadataStore(config.configBucket, config)
   metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
 
-  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, metaDataConfigStore)
+  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, metaDataConfigStore, usageRightsConfigStore)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)


### PR DESCRIPTION
## What does this change?
Puts regex matches of credit and source metadata into usage rights config which is read in from usage_rights.json in s3. Keeps all the special cases from the guardian hardcoded and checked for after matching on the configurable regexes.


<details><summary>usage_rights.json</summary>
<p>

#### The json file to be put in `s3.config.bucket`

```
{
  "supplierCreditMatches": [{
      "name": "AapParser",
      "creditMatches": ["AAPIMAGE", "AAP IMAGE", "AAP"],
      "sourceMatches": []
    },
    {
      "name": "ActionImagesParser",
      "creditMatches": ["Action Images", "Action Images via Reuters"],
      "sourceMatches": []
    },
    {
      "name": "AlamyParser",
      "creditMatches": ["Alamy", "Alamy Stock Photo"],
      "sourceMatches": []
    },
    {
      "name": "AllStarParser",
      "creditMatches": ["Allstar Picture Library"],
      "sourceMatches": []
    },
    {
      "name": "ApParser",
      "creditMatches": ["ap", "associated press"],
      "sourceMatches": []
    },
    {
      "name": "BarcroftParser",
      "creditMatches": ["barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"],
      "sourceMatches": ["barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"]
    },
    {
      "name": "BloombergParser",
      "creditMatches": ["Bloomberg"],
      "sourceMatches": []
    },
    {
      "name": "CorbisParser",
      "creditMatches": [],
      "sourceMatches": ["Corbis"]
    },
    {
      "name": "EpaParser",
      "creditMatches": [".*\\bEPA\\b.*"],
      "sourceMatches": []
    },
    {
      "name": "GettyXmpParser",
      "creditMatches": [],
      "sourceMatches": []
    },
    {
      "name": "GettyCreditParser",
      "creditMatches": [".*Getty Images.*", ".+ via Getty(?: .*)?", ".+/Getty(?: .*)?"],
      "sourceMatches": []
    },
    {
      "name": "PaParser",
      "creditMatches": [
        "PA",
        "PA WIRE",
        "PA Wire/PA Images",
        "PA Wire/PA Photos",
        "PA Wire/Press Association Images",
        "PA Archive/PA Photos",
        "PA Archive/PA Images",
        "PA Archive/Press Association Ima",
        "PA Archive/Press Association Images",
        "Press Association Images"
      ],
      "sourceMatches": []
    },
    {
      "name": "ReutersParser",
      "creditMatches": ["REUTERS", "Reuters", "RETUERS", "REUTERS/", "PAUL TRICKETT via REUTERS"],
      "sourceMatches": []
    },
    {
      "name": "RexParser",
      "creditMatches": [".+/ Rex Features"],
      "sourceMatches": ["Rex Features", "REX/Shutterstock"]
    },
    {
      "name": "RonaldGrantParser",
      "creditMatches": ["www.ronaldgrantarchive.com", "Ronald Grant Archive"],
      "sourceMatches": []
    }
  ],
  "usageRights": [
    "NoRights",
    "Handout",
    "PrImage",
    "Screengrab",
    "SocialMedia",
    "Agency",
    "CommissionedAgency",
    "Chargeable",
    "Bylines",
    "StaffPhotographer",
    "ContractPhotographer",
    "CommissionedPhotographer",
    "CreativeCommons",
    "Pool",
    "CrownCopyright",
    "Obituary",
    "ContractIllustrator",
    "CommissionedIllustrator",
    "StaffIllustrator",
    "Composite",
    "PublicDomain"
  ],
  "freeSuppliers": [
    "AAP",
    "Alamy",
    "Allstar Picture Library",
    "AP",
    "Barcroft Media",
    "Bloomberg",
    "Getty Images",
    "PA",
    "Reuters",
    "Rex Features",
    "Ronald Grant Archive",
    "Action Images",
    "Action Images via Reuters",
    "AFP"
  ],
  "suppliersCollectionExcl": {
    "Getty Images": [
      "Arnold Newman Collection",
      "360cities.net Editorial",
      "360cities.net RM",
      "age fotostock RM",
      "Alinari",
      "Arnold Newman Collection",
      "ASAblanca",
      "Barcroft Media",
      "Bloomberg",
      "Bob Thomas Sports Photography",
      "Carnegie Museum of Art",
      "Catwalking",
      "Contour",
      "Contour RA",
      "Corbis Premium Historical",
      "Editorial Specials",
      "Reportage Archive",
      "Gamma-Legends",
      "Genuine Japan Editorial Stills",
      "Genuine Japan Creative Stills",
      "George Steinmetz",
      "Getty Images Sport Classic",
      "Iconic Images",
      "Iconica",
      "Icon Sport",
      "Kyodo News Stills",
      "Lichfield Studios Limited",
      "Lonely Planet Images",
      "Lonely Planet RF",
      "Masters",
      "Major League Baseball Platinum",
      "Moment Select",
      "Mondadori Portfolio Premium",
      "National Geographic",
      "National Geographic RF",
      "National Geographic Creative",
      "National Geographic Magazines",
      "NBA Classic",
      "Neil Leifer Collection",
      "Newspix",
      "PA Images",
      "Papixs",
      "Paris Match Archive",
      "Paris Match Collection",
      "Pele 10",
      "Photonica",
      "Photonica World",
      "Popperfoto",
      "Popperfoto Creative",
      "Premium Archive",
      "Reportage Archive",
      "SAMURAI JAPAN",
      "Sports Illustrated",
      "Sports Illustrated Classic",
      "Sportsfile",
      "Sygma Premium",
      "Terry O'Neill",
      "The Asahi Shimbun Premium",
      "The LIFE Premium Collection",
      "ullstein bild Premium",
      "Ulrich Baumgarten",
      "VII Premium",
      "Vision Media",
      "Xinhua News Agency"
    ]
  }
}
```

</p>
</details>