### PR TITLE
configure which agency parsers are used to assign agency to an image

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -21,27 +21,33 @@ trait ImageProcessor {
 }
 
 class SupplierProcessors(metadataConfig: MetadataConfig) {
-  val all: List[ImageProcessor] = List(
-    GettyXmpParser,
-    GettyCreditParser,
-    AapParser,
-    ActionImagesParser,
-    AlamyParser,
-    AllStarParser,
-    ApParser,
-    BarcroftParser,
-    BloombergParser,
-    CorbisParser,
-    EpaParser,
-    PaParser,
-    ReutersParser,
-    RexParser,
-    RonaldGrantParser,
-    new PhotographerParser(metadataConfig)
+  val supplierMap = Map(
+    "GettyXmp"    -> GettyXmpParser,
+    "GettyCredit" -> GettyCreditParser,
+    "Aap"         -> AapParser,
+    "ActionImages"-> ActionImagesParser,
+    "Alamy"       -> AlamyParser,
+    "AllStar"     -> AllStarParser,
+    "Ap"          -> ApParser,
+    "Barcroft"    -> BarcroftParser,
+    "Bloomberg"   -> BloombergParser,
+    "Corbis"      -> CorbisParser,
+    "Epa"         -> EpaParser,
+    "Pa"          -> PaParser,
+    "Reuters"     -> ReutersParser,
+    "Rex"         -> RexParser,
+    "RonaldGrant" -> RonaldGrantParser,
+    "Afp"         -> AfpParser,
+    "Photographer"-> new PhotographerParser(metadataConfig)
   )
 
+  def getAll(supplierList: List[String]) =
+    supplierList
+      .map(supplierMap.get)
+      .collect { case Some(processor) => processor }
+
   def process(image: Image, c: UsageRightsConfig): Image =
-    all.foldLeft(image) { case (im, processor) => processor(im, c.supplierCreditMatches) }
+    getAll(c.supplierParsers).foldLeft(image) { case (im, processor) => processor(im, c.supplierCreditMatches) }
 }
 
 class PhotographerParser(metadataConfig: MetadataConfig) extends ImageProcessor {
@@ -305,6 +311,15 @@ object RonaldGrantParser extends ImageProcessor {
       image.copy(
         usageRights = Agency("Ronald Grant Archive"),
         metadata = image.metadata.copy(credit = Some("Ronald Grant"))
+      )
+    else image
+}
+
+object AfpParser extends ImageProcessor {
+  def apply(image: Image, matches: List[SupplierMatch]): Image =
+    if (matchesCreditOrSource(image, "AfpParser", matches))
+      image.copy(
+        usageRights = Agency("AFP"),
       )
     else image
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -4,6 +4,7 @@ import play.api.libs.json._
 
 case class UsageRightsConfig(
                               supplierCreditMatches: List[SupplierMatch],
+                              supplierParsers: List[String],
                               usageRights: List[String],
                               freeSuppliers: List[String],
                               suppliersCollectionExcl: Map[String, List[String]]) {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -467,8 +467,22 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     }
   }
 
+  describe("AFP") {
+    it("should match AFP credit") {
+      val image = createImageFromMetadata("credit" -> "AFP/Getty Images")
+      val processedImage = applyProcessors(image, List(SupplierMatch("AfpParser", List("AFP/.*"), List("AFP"))))
+      processedImage.usageRights should be(Agency("AFP"))
+    }
 
-  def applyProcessors(image: Image): Image = {
+    it("should match AFP source") {
+      val image = createImageFromMetadata("source" -> "AFP")
+      val processedImage = applyProcessors(image, List(SupplierMatch("AfpParser", List("AFP/.*"), List("AFP"))))
+      processedImage.usageRights should be(Agency("AFP"))
+    }
+  }
+
+
+  def applyProcessors(image: Image, extraSupplierMatches: List[SupplierMatch] = List()): Image = {
 
     val matches: List[SupplierMatch] =
       List(
@@ -486,10 +500,31 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
         SupplierMatch("PaParser", List("PA", "PA WIRE", "PA Wire/PA Images", "PA Wire/PA Photos", "PA Wire/Press Association Images", "PA Archive/PA Photos", "PA Archive/PA Images", "PA Archive/Press Association Ima", "PA Archive/Press Association Images", "Press Association Images"), List()),
         SupplierMatch("ReutersParser", List("REUTERS", "Reuters", "RETUERS", "REUTERS/"), List()),
         SupplierMatch("RexParser", List(".+/ Rex Features"), List("Rex Features", "REX/Shutterstock")),
-        SupplierMatch("RonaldGrantParser", List("www.ronaldgrantarchive.com", "Ronald Grant Archive"), List())
-      )
+        SupplierMatch("RonaldGrantParser", List("www.ronaldgrantarchive.com", "Ronald Grant Archive"), List()),
+      ) ++ extraSupplierMatches
+
+    val supplierParsers = List(
+      "GettyXmp",
+      "GettyCredit",
+      "Aap",
+      "ActionImages",
+      "Alamy",
+      "AllStar",
+      "Ap",
+      "Barcroft",
+      "Bloomberg",
+      "Corbis",
+      "Epa",
+      "Pa",
+      "Reuters",
+      "Rex",
+      "RonaldGrant",
+      "Afp",
+      "Photographer"
+    )
+
     val usageRightsConfig =
-      UsageRightsConfig(matches, List(), List(), Map())
+      UsageRightsConfig(matches, supplierParsers, List(), List(), Map())
 
     val metadataConfig =
       MetadataConfig(List(), List(),

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -36,7 +36,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
   val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = es6TestUrl,
     cluster = "media-service-test", shards = 1, replicas = 0)
 
-  private val usageRightsConfig = UsageRightsConfig(List(), List(), List(), Map("" -> List()))
+  private val usageRightsConfig = UsageRightsConfig(List(), List(), List(), List(), Map("" -> List()))
 
   private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => List.empty, () => usageRightsConfig)
   val client = ES.client

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -14,7 +14,7 @@ class CostCalculatorTest extends AsyncFunSpec with Matchers with MockitoSugar {
     val Quota = mock[UsageQuota]
     val usageRightsStore = mock[UsageRightsStore]
 
-    when(usageRightsStore.get) thenReturn UsageRightsConfig(List(), List(), List("Getty Images"), Map("Getty Images" -> List("Terry O'Neill")))
+    when(usageRightsStore.get) thenReturn UsageRightsConfig(List(), List(), List(), List("Getty Images"), Map("Getty Images" -> List("Terry O'Neill")))
 
     object Costing extends CostCalculator(usageRightsStore, Quota) {
       override def getOverQuota(usageRights: UsageRights) = None


### PR DESCRIPTION
## What does this change?
In order for this to be merged, [2612](https://github.com/guardian/grid/pull/2612) then [2614](https://github.com/guardian/grid/pull/2614) and then [2618](https://github.com/guardian/grid/pull/2618) must be merged first.

Makes which parsers are used in `SupplierProcessors.scala` configurable to make rights assigment easier to customise. This is of particular use to us (BBC) as we want to have AFP as a separate supplier whereas the guardian has this as a collection of Getty. 

The list of which parsers are used are kept in `usage_rights.json` as with related PRs^^. 

Here is the updated usage_rights.json, which is the same as the json for [2618](https://github.com/guardian/grid/pull/2618) but with addition of the `supplierParsers` field.

<details><summary>usage_rights.json</summary>
<p>

#### The full json file to be put in `s3.config.bucket`

```
{
  "supplierCreditMatches": [{
      "name": "AapParser",
      "creditMatches": ["AAPIMAGE", "AAP IMAGE", "AAP"],
      "sourceMatches": []
    },
    {
      "name": "ActionImagesParser",
      "creditMatches": ["Action Images", "Action Images via Reuters"],
      "sourceMatches": []
    },
    {
      "name": "AlamyParser",
      "creditMatches": ["Alamy", "Alamy Stock Photo"],
      "sourceMatches": []
    },
    {
      "name": "AllStarParser",
      "creditMatches": ["Allstar Picture Library"],
      "sourceMatches": []
    },
    {
      "name": "ApParser",
      "creditMatches": ["ap", "associated press"],
      "sourceMatches": []
    },
    {
      "name": "BarcroftParser",
      "creditMatches": ["barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"],
      "sourceMatches": ["barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"]
    },
    {
      "name": "BloombergParser",
      "creditMatches": ["Bloomberg"],
      "sourceMatches": []
    },
    {
      "name": "CorbisParser",
      "creditMatches": [],
      "sourceMatches": ["Corbis"]
    },
    {
      "name": "EpaParser",
      "creditMatches": [".*\\bEPA\\b.*"],
      "sourceMatches": []
    },
    {
      "name": "GettyXmpParser",
      "creditMatches": [],
      "sourceMatches": []
    },
    {
      "name": "GettyCreditParser",
      "creditMatches": [".*Getty Images.*", ".+ via Getty(?: .*)?", ".+/Getty(?: .*)?"],
      "sourceMatches": []
    },
    {
      "name": "PaParser",
      "creditMatches": [
        "PA",
        "PA WIRE",
        "PA Wire/PA Images",
        "PA Wire/PA Photos",
        "PA Wire/Press Association Images",
        "PA Archive/PA Photos",
        "PA Archive/PA Images",
        "PA Archive/Press Association Ima",
        "PA Archive/Press Association Images",
        "Press Association Images"
      ],
      "sourceMatches": ["PA"]
    },
    {
      "name": "ReutersParser",
      "creditMatches": ["REUTERS", "Reuters", "RETUERS", "REUTERS/", "PAUL TRICKETT via REUTERS"],
      "sourceMatches": []
    },
    {
      "name": "RexParser",
      "creditMatches": [".+/ Rex Features"],
      "sourceMatches": ["Rex Features", "REX/Shutterstock"]
    },
    {
      "name": "RonaldGrantParser",
      "creditMatches": ["www.ronaldgrantarchive.com", "Ronald Grant Archive"],
      "sourceMatches": []
    }
  ], 
  "supplierParsers": [
    "GettyXmp",   
    "GettyCredit",
    "Aap",        
    "ActionImages",
    "Alamy",       
    "AllStar",     
    "Ap",          
    "Barcroft",    
    "Bloomberg",   
    "Corbis",      
    "Epa",         
    "Pa",         
    "Reuters",     
    "Rex",         
    "RonaldGrant",
    "Afp",
    "Photographer" 
  ],
  "usageRights": [
    "NoRights",
    "Handout",
    "PrImage",
    "Screengrab",
    "SocialMedia",
    "Agency",
    "CommissionedAgency",
    "Chargeable",
    "Bylines",
    "StaffPhotographer",
    "ContractPhotographer",
    "CommissionedPhotographer",
    "CreativeCommons",
    "Pool",
    "CrownCopyright",
    "Obituary",
    "ContractIllustrator",
    "CommissionedIllustrator",
    "StaffIllustrator",
    "Composite",
    "PublicDomain"
  ],
  "freeSuppliers": [
    "AAP",
    "Alamy",
    "Allstar Picture Library",
    "AP",
    "Barcroft Media",
    "Bloomberg",
    "Getty Images",
    "PA",
    "Reuters",
    "Rex Features",
    "Ronald Grant Archive",
    "Action Images",
    "Action Images via Reuters",
    "AFP"
  ],
  "suppliersCollectionExcl": {
    "Getty Images": [
      "Arnold Newman Collection",
      "360cities.net Editorial",
      "360cities.net RM",
      "age fotostock RM",
      "Alinari",
      "Arnold Newman Collection",
      "ASAblanca",
      "Barcroft Media",
      "Bloomberg",
      "Bob Thomas Sports Photography",
      "Carnegie Museum of Art",
      "Catwalking",
      "Contour",
      "Contour RA",
      "Corbis Premium Historical",
      "Editorial Specials",
      "Reportage Archive",
      "Gamma-Legends",
      "Genuine Japan Editorial Stills",
      "Genuine Japan Creative Stills",
      "George Steinmetz",
      "Getty Images Sport Classic",
      "Iconic Images",
      "Iconica",
      "Icon Sport",
      "Kyodo News Stills",
      "Lichfield Studios Limited",
      "Lonely Planet Images",
      "Lonely Planet RF",
      "Masters",
      "Major League Baseball Platinum",
      "Moment Select",
      "Mondadori Portfolio Premium",
      "National Geographic",
      "National Geographic RF",
      "National Geographic Creative",
      "National Geographic Magazines",
      "NBA Classic",
      "Neil Leifer Collection",
      "Newspix",
      "PA Images",
      "Papixs",
      "Paris Match Archive",
      "Paris Match Collection",
      "Pele 10",
      "Photonica",
      "Photonica World",
      "Popperfoto",
      "Popperfoto Creative",
      "Premium Archive",
      "Reportage Archive",
      "SAMURAI JAPAN",
      "Sports Illustrated",
      "Sports Illustrated Classic",
      "Sportsfile",
      "Sygma Premium",
      "Terry O'Neill",
      "The Asahi Shimbun Premium",
      "The LIFE Premium Collection",
      "ullstein bild Premium",
      "Ulrich Baumgarten",
      "VII Premium",
      "Vision Media",
      "Xinhua News Agency"
    ]
  }
}
```

</p>
</details> 

An extra parser for AFP has been added. A test is added for this case.

## Tested?
- [x] locally
- [ ] on TEST
