### PR TITLE
Api request cloudwatch metrics

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -50,6 +50,11 @@ trait CommonConfig {
 
   lazy val thrallKinesisStream = properties("thrall.kinesis.stream.name")
 
+  lazy val requestMetricsEnabled: Boolean = properties.getOrElse("metrics.request.enabled", "false").toLowerCase match {
+    case "true" => true
+    case _ => false
+  }
+
   // Note: had to make these lazy to avoid init order problems ;_;
   lazy val domainRoot: String = properties("domain.root")
   lazy val rootAppName: String = properties.getOrElse("app.name.root", "media")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
@@ -91,10 +91,10 @@ abstract class CloudWatchMetrics(namespace: String, config: CommonConfig) {
     metricDatumOriginal.getStatisticValues match {
       case stats if stats == null =>
         new StatisticSet()
-          .withMinimum(metricDatumOriginal.getValue)
-          .withMaximum(metricDatumOriginal.getValue)
-          .withSum(metricDatumOriginal.getValue)
-          .withSampleCount(1d)
+          .withMinimum(Math.min(metricDatumOriginal.getValue, metricDatumNew.getValue))
+          .withMaximum(Math.max(metricDatumOriginal.getValue, metricDatumNew.getValue))
+          .withSum(metricDatumOriginal.getValue + metricDatumNew.getValue)
+          .withSampleCount(if (metricDatumOriginal.getUnit.equals(StandardUnit.Count.toString)) 1d else 2d)
       case stats =>
         new StatisticSet()
           .withMinimum(Math.min(stats.getMinimum, metricDatumNew.getValue))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
@@ -1,17 +1,16 @@
 package com.gu.mediaservice.lib.metrics
 
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
+import com.amazonaws.services.cloudwatch.model._
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.gu.mediaservice.lib.config.CommonConfig
 import org.slf4j.LoggerFactory
+import scalaz.concurrent.Task
+import scalaz.stream.Process.{constant, emitAll}
+import scalaz.stream.async.mutable.Topic
+import scalaz.stream.{Sink, async}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scalaz.concurrent.Task
-import scalaz.stream.Process.{constant, emitAll}
-import scalaz.stream.{Sink, async}
-import scalaz.stream.async.mutable.Topic
 
 trait Metric[A] {
 
@@ -29,7 +28,7 @@ abstract class CloudWatchMetrics(namespace: String, config: CommonConfig) {
   /** The maximum number of data points to report in one batch.
     * (Each batch costs 1 HTTP request to CloudWatch)
     */
-  val maxChunkSize: Int = 20
+  val maxChunkSize: Int = Int.MaxValue
 
   /** The maximum time to wait between reports, when there is data enqueued.
     *
@@ -68,10 +67,41 @@ abstract class CloudWatchMetrics(namespace: String, config: CommonConfig) {
   private val client: AmazonCloudWatch = config.withAWSCredentials(AmazonCloudWatchClientBuilder.standard()).build()
 
   private def putData(data: Seq[MetricDatum]): Task[Unit] = Task {
-    client.putMetricData(new PutMetricDataRequest()
-      .withNamespace(namespace)
-      .withMetricData(data.asJava))
-    logger.info(s"Put ${data.size} metric data points to namespace $namespace")
+
+    val aggregatedMetrics: Seq[MetricDatum] = data
+      .groupBy(metric => (metric.getMetricName, metric.getDimensions))
+      .map { case (_, values) =>
+        values.reduce((m1, m2) => m1.clone()
+          .withValue(null)
+          .withStatisticValues(aggregateMetricStats(m1,m2)))
+      }
+      .toSeq
+
+    aggregatedMetrics.grouped(20).foreach(chunkedMetrics => { //can only send max 20 metrics to CW at a time
+      client.putMetricData(new PutMetricDataRequest()
+        .withNamespace(namespace)
+        .withMetricData(chunkedMetrics.asJava))
+      }
+    )
+
+    logger.info(s"Put ${data.size} metric data points (aggregated to ${aggregatedMetrics.size} points) to namespace $namespace")
+  }
+
+  private def aggregateMetricStats(metricDatumOriginal: MetricDatum, metricDatumNew: MetricDatum): StatisticSet = {
+    metricDatumOriginal.getStatisticValues match {
+      case stats if stats == null =>
+        new StatisticSet()
+          .withMinimum(metricDatumOriginal.getValue)
+          .withMaximum(metricDatumOriginal.getValue)
+          .withSum(metricDatumOriginal.getValue)
+          .withSampleCount(1d)
+      case stats =>
+        new StatisticSet()
+          .withMinimum(Math.min(stats.getMinimum, metricDatumNew.getValue))
+          .withMaximum(Math.max(stats.getMinimum, metricDatumNew.getValue))
+          .withSum(stats.getSum + metricDatumNew.getValue)
+          .withSampleCount(if (metricDatumOriginal.getUnit.equals(StandardUnit.Count.toString)) 1d else stats.getSampleCount + 1)
+    }
   }
 
   abstract class CloudWatchMetric[A](val name: String) extends Metric[A] {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -24,7 +24,7 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
   implicit val ec: ExecutionContext = executionContext
 
   final override def httpFilters: Seq[EssentialFilter] = {
-    Seq(corsFilter, csrfFilter, securityHeadersFilter, gzipFilter, new RequestLoggingFilter(materializer))
+    Seq(corsFilter, csrfFilter, securityHeadersFilter, gzipFilter, new RequestLoggingFilter(materializer), new RequestMetricFilter(config, materializer))
   }
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestMetricFilter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestMetricFilter.scala
@@ -1,0 +1,51 @@
+package com.gu.mediaservice.lib.play
+
+import akka.stream.Materializer
+import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+class RequestMetricFilter(val config: CommonConfig, override val mat: Materializer)(implicit ec: ExecutionContext) extends Filter {
+  val namespace: String = s"${config.stage}/${config.appName.split('-').map(_.toLowerCase.capitalize).mkString("")}"
+  val enabled: Boolean = config.requestMetricsEnabled
+
+  object RequestMetrics extends CloudWatchMetrics(namespace, config) {
+    val totalRequests = new CountMetric("TotalRequests")
+    val successfulRequests = new CountMetric("SuccessfulRequests")
+    val failedRequests = new CountMetric("FailedRequests")
+    val requestDuration = new TimeMetric("RequestDuration")
+  }
+
+  override def apply(next: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
+    val start = System.currentTimeMillis()
+    val result = next(rh)
+
+    if (enabled && shouldRecord(rh)) {
+      RequestMetrics.totalRequests.increment().run
+      result onComplete {
+        case Success(_) =>
+          RequestMetrics.successfulRequests.increment().run
+          val duration = System.currentTimeMillis() - start
+          RequestMetrics.requestDuration.runRecordOne(duration)
+
+        case Failure(_) =>
+          RequestMetrics.failedRequests.increment().run
+          val duration = System.currentTimeMillis() - start
+          RequestMetrics.requestDuration.runRecordOne(duration)
+
+      }
+    }
+
+    result
+  }
+
+  def shouldRecord(request: RequestHeader): Boolean = {
+    request.path match {
+      case "/management/healthcheck" => false
+      case _ => true
+    }
+  }
+}

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -9,6 +9,7 @@ function getAuthConfig(config) {
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |aws.region=${config.aws.region}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -21,6 +22,7 @@ function getCollectionsConfig(config) {
         |dynamo.table.collections=${config.stackProps.CollectionsDynamoTable}
         |dynamo.table.imageCollections=${config.stackProps.ImageCollectionsDynamoTable}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -33,6 +35,7 @@ function getCropperConfig(config) {
         |publishing.image.host=${config.stackProps.ImageOriginBucket}.s3.amazonaws.com
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -44,6 +47,7 @@ function getImageLoaderConfig(config) {
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -62,6 +66,7 @@ function getKahunaConfig(config) {
         |links.usageRightsHelp=${config.links.usageRightsHelp}
         |links.invalidSessionHelp=${config.links.invalidSessionHelp}
         |links.supportEmail=${config.links.supportEmail}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -72,6 +77,7 @@ function getLeasesConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |dynamo.tablename.leasesTable=${config.stackProps.LeasesDynamoTable}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -92,6 +98,7 @@ function getMediaApiConfig(config) {
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |quota.store.key=rcs-quota.json
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -104,6 +111,7 @@ function getMetadataEditorConfig(config) {
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |dynamo.table.edits=${config.stackProps.EditsDynamoTable}
         |indexed.images.sqs.queue.url=${config.stackProps.IndexedImageMetadataQueueUrl}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -133,6 +141,7 @@ function getThrallConfig(config) {
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |metrics.request.enabled=false
         |`;
 }
 
@@ -151,6 +160,7 @@ function getUsageConfig(config) {
         |crier.preview.name=${config.crier.preview.streamName}
         |crier.live.name=${config.crier.live.streamName}
         |app.name=usage
+        |metrics.request.enabled=false
         |`;
 }
 


### PR DESCRIPTION
## What does this change?

This sends CloudWatch metrics for each received request per service (ignoring healthcheck requests). The idea being that it will allow for us to see how many requests per min each service is receiving, if there are any failed requests, and the average length of time each request is taking. The way the cloudwatch metrics are sent has also been slightly modified so that they get aggregated first into a statistic set, this is a lot more useful for count metrics when deployed on multiple instances as it then allows for you to see the average over the amount of instances (e.g. 3 instances each get 100 requests each, you will see an average of 100).

A configurable property has been added `metrics.request.enabled=false` (defaults to false if not present) which can be toggled on a service by service basis if metrics are only desired for a particular service.

Not 100% sure if this is useful for you guys, but thought I'd create a PR none the less!

## Tested?
- [x] locally
- [ ] on TEST
