### PR TITLE
Costing flags per agency

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -1,10 +1,12 @@
 package com.gu.mediaservice.lib.config
 
+import com.gu.mediaservice.model.Cost
 import play.api.libs.json._
 
 case class UsageRightsConfig(
                               supplierCreditMatches: List[SupplierMatch],
                               supplierParsers: List[String],
+                              supplierCostings: Map[String, Cost],
                               usageRights: List[String],
                               freeSuppliers: List[String],
                               suppliersCollectionExcl: Map[String, List[String]]) {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -53,7 +53,7 @@ object UsageRights {
     usageRights
       .map(usageRightsMap.get)
       .collect { case Some(spec) => spec }
-  
+
 
   val photographer = List(StaffPhotographer, ContractPhotographer, CommissionedPhotographer)
   val illustrator = List(StaffIllustrator, ContractIllustrator, CommissionedIllustrator)
@@ -205,12 +205,12 @@ object Agencies {
 
 final case class Agency(supplier: String, suppliersCollection: Option[String] = None,
                         restrictions: Option[String] = None) extends UsageRights  {
-  val defaultCost = Agency.defaultCost
+  val defaultCost = None
   def id: Option[String] = Agencies.lookupId(supplier)
 }
 object Agency extends UsageRightsSpec {
   val category = "agency"
-  val defaultCost = None
+  val defaultCost = Some(Pay)
   val name = "Agency - subscription"
   val description =
     "Agencies such as Getty, Reuters, Press Association, etc. where subscription fees are paid to access and use pictures."
@@ -347,7 +347,7 @@ object Obituary extends UsageRightsSpec {
 
 
 final case class StaffPhotographer(photographer: String, publication: String,
-                             restrictions: Option[String] = None) extends Photographer {
+                                   restrictions: Option[String] = None) extends Photographer {
   val defaultCost = StaffPhotographer.defaultCost
 }
 object StaffPhotographer extends UsageRightsSpec {
@@ -363,7 +363,7 @@ object StaffPhotographer extends UsageRightsSpec {
 
 
 final case class ContractPhotographer(photographer: String, publication: Option[String] = None,
-                                restrictions: Option[String] = None) extends Photographer {
+                                      restrictions: Option[String] = None) extends Photographer {
   val defaultCost = ContractPhotographer.defaultCost
 }
 object ContractPhotographer extends UsageRightsSpec {
@@ -379,7 +379,7 @@ object ContractPhotographer extends UsageRightsSpec {
 
 
 final case class CommissionedPhotographer(photographer: String, publication: Option[String] = None,
-                                    restrictions: Option[String] = None) extends Photographer {
+                                          restrictions: Option[String] = None) extends Photographer {
   val defaultCost = CommissionedPhotographer.defaultCost
 }
 object CommissionedPhotographer extends UsageRightsSpec {
@@ -472,7 +472,7 @@ object CommissionedIllustrator extends UsageRightsSpec {
 
 
 final case class CreativeCommons(licence: String, source: String, creator: String, contentLink: String,
-                           restrictions: Option[String] = None) extends UsageRights {
+                                 restrictions: Option[String] = None) extends UsageRights {
   val defaultCost = CreativeCommons.defaultCost
 }
 object CreativeCommons extends UsageRightsSpec {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -524,7 +524,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     )
 
     val usageRightsConfig =
-      UsageRightsConfig(matches, supplierParsers, List(), List(), Map())
+      UsageRightsConfig(matches, supplierParsers, Map(), List(), List(), Map())
 
     val metadataConfig =
       MetadataConfig(List(), List(),

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
@@ -17,6 +17,7 @@ class SearchFilters(config: MediaApiConfig, usageRightsConfig: () => UsageRights
   val usageRights: List[String] = usageRightsConf.usageRights
   val freeSuppliers: List[String] = usageRightsConf.freeSuppliers
   val suppliersCollectionExcl: Map[String, List[String]] = usageRightsConf.suppliersCollectionExcl
+  val supplierCostingsMap: Map[String, Cost] = usageRightsConf.supplierCostings
 
   // Warning: The current media-api definition of invalid includes other requirements
   // so does not match this filter exactly!
@@ -36,7 +37,8 @@ class SearchFilters(config: MediaApiConfig, usageRightsConfig: () => UsageRights
 
   val suppliersWithExclusionsFilter: Option[Query] = suppliersWithExclusionsFilters.toNel.map(filters.or)
   val suppliersNoExclusionsFilter: Option[Query] = suppliersNoExclusions.toNel.map(filters.terms(usageRightsField("supplier"), _))
-  val freeSupplierFilter: Option[Query] = filterOrFilter(suppliersWithExclusionsFilter, suppliersNoExclusionsFilter)
+  val freeSuppliersCostFilter: Option[Query] = freeToUseSuppliers.toNel.map(filters.terms(usageRightsField("supplier"), _))
+  val freeSupplierFilter: Option[Query] = filterAndFilter(filterOrFilter(suppliersWithExclusionsFilter, suppliersNoExclusionsFilter), freeSuppliersCostFilter)
 
   // We're showing `Conditional` here too as we're considering them potentially
   // free. We could look into sending over the search query as a cost filter
@@ -52,6 +54,9 @@ class SearchFilters(config: MediaApiConfig, usageRightsConfig: () => UsageRights
 
   lazy val freeToUseCategories: List[String] =
     UsageRights.getAll(usageRights).filter(ur => ur.defaultCost.exists(cost => cost == Free || cost == Conditional)).map(ur => ur.category)
+
+  lazy val freeToUseSuppliers: List[String] =
+    freeSuppliers.filter(s => supplierCostingsMap.get(s).exists(cost => cost == Free || cost == Conditional))
 
   val persistedCategories = NonEmptyList(
     StaffPhotographer.category,

--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -11,10 +11,12 @@ case class CostCalculator(usageRightsStore: UsageRightsStore, quotas: UsageQuota
   val defaultCost = Pay
 
   def getCost(supplier: String, collection: Option[String]): Option[Cost] = {
-    val c = usageRightsStore.get
-    val free = c.isFreeSupplier(supplier) && ! collection.exists(c.isExcludedColl(supplier, _))
+    val costingPerAgency = usageRightsStore.get.supplierCostings
 
-    if (free) Some(Free) else None
+    val c = usageRightsStore.get
+    val excluded = collection.exists(c.isExcludedColl(supplier, _))
+
+    if (excluded) None else costingPerAgency.get(supplier)
   }
 
   def isConditional(usageRights: UsageRights): Boolean =

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -36,7 +36,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
   val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = es6TestUrl,
     cluster = "media-service-test", shards = 1, replicas = 0)
 
-  private val usageRightsConfig = UsageRightsConfig(List(), List(), List(), List(), Map("" -> List()))
+  private val usageRightsConfig = UsageRightsConfig(List(), List(), Map(), List(), List(), Map())
 
   private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => List.empty, () => usageRightsConfig)
   val client = ES.client

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -14,7 +14,16 @@ class CostCalculatorTest extends AsyncFunSpec with Matchers with MockitoSugar {
     val Quota = mock[UsageQuota]
     val usageRightsStore = mock[UsageRightsStore]
 
-    when(usageRightsStore.get) thenReturn UsageRightsConfig(List(), List(), List(), List("Getty Images"), Map("Getty Images" -> List("Terry O'Neill")))
+    when(usageRightsStore.get) thenReturn UsageRightsConfig(List(), List(),
+      Map(
+        "Rex Features"-> Pay,
+        "Alamy"       -> Pay,
+        "Reuters"     -> Pay,
+        "EPA"         -> Conditional,
+        "Getty Images"-> Free,
+        "AFP"         -> Conditional,
+        "PA"          -> Conditional
+      ),List(), List("Getty Images"), Map("Getty Images" -> List("Terry O'Neill")))
 
     object Costing extends CostCalculator(usageRightsStore, Quota) {
       override def getOverQuota(usageRights: UsageRights) = None
@@ -56,6 +65,20 @@ class CostCalculatorTest extends AsyncFunSpec with Matchers with MockitoSugar {
 
     it("should not be pay-for with a free supplier but excluded collection") {
       val usageRights = Agency("Getty Images", Some("Terry O'Neill"))
+      val cost = Costing.getCost(usageRights)
+
+      cost should be (Pay)
+    }
+
+    it("should be Conditional for an agency set to be conditional in usage rights config") {
+      val usageRights = Agency("EPA")
+      val cost = Costing.getCost(usageRights)
+
+      cost should be (Conditional)
+    }
+
+    it("should be Pay for an agency set to be pay in usage rights config") {
+      val usageRights = Agency("Alamy")
       val cost = Costing.getCost(usageRights)
 
       cost should be (Pay)


### PR DESCRIPTION
[2612](https://github.com/guardian/grid/pull/2612), [2614](https://github.com/guardian/grid/pull/2614), [2618](https://github.com/guardian/grid/pull/2618) and [2620](https://github.com/guardian/grid/pull/2620) must be merged first.

## What does this change?
Allows the costing of each agency to be configured. We (BBC) have a requirement to have different flags on images per agency (Red/Amber). This allows you to specify what the costing should be for each agency.

## How can success be measured?

Here is the updated usage_rights.json, which is the same as the json for [2620](https://github.com/guardian/grid/pull/2620) but with addition of the `supplierCostings` field. 

<details><summary>usage_rights.json</summary>
<p>

#### The full json file to be put in `s3.config.bucket`

```
{
  "supplierCreditMatches": [{
      "name": "AapParser",
      "creditMatches": ["AAPIMAGE", "AAP IMAGE", "AAP"],
      "sourceMatches": []
    },
    {
      "name": "ActionImagesParser",
      "creditMatches": ["Action Images", "Action Images via Reuters"],
      "sourceMatches": []
    },
    {
      "name": "AlamyParser",
      "creditMatches": ["Alamy", "Alamy Stock Photo"],
      "sourceMatches": []
    },
    {
      "name": "AllStarParser",
      "creditMatches": ["Allstar Picture Library"],
      "sourceMatches": []
    },
    {
      "name": "ApParser",
      "creditMatches": ["ap", "associated press"],
      "sourceMatches": []
    },
    {
      "name": "BarcroftParser",
      "creditMatches": ["barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"],
      "sourceMatches": ["barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars"]
    },
    {
      "name": "BloombergParser",
      "creditMatches": ["Bloomberg"],
      "sourceMatches": []
    },
    {
      "name": "CorbisParser",
      "creditMatches": [],
      "sourceMatches": ["Corbis"]
    },
    {
      "name": "EpaParser",
      "creditMatches": [".*\\bEPA\\b.*"],
      "sourceMatches": []
    },
    {
      "name": "GettyXmpParser",
      "creditMatches": [],
      "sourceMatches": []
    },
    {
      "name": "GettyCreditParser",
      "creditMatches": [".*Getty Images.*", ".+ via Getty(?: .*)?", ".+/Getty(?: .*)?"],
      "sourceMatches": []
    },
    {
      "name": "PaParser",
      "creditMatches": [
        "PA",
        "PA WIRE",
        "PA Wire/PA Images",
        "PA Wire/PA Photos",
        "PA Wire/Press Association Images",
        "PA Archive/PA Photos",
        "PA Archive/PA Images",
        "PA Archive/Press Association Ima",
        "PA Archive/Press Association Images",
        "Press Association Images"
      ],
      "sourceMatches": ["PA"]
    },
    {
      "name": "ReutersParser",
      "creditMatches": ["REUTERS", "Reuters", "RETUERS", "REUTERS/", "PAUL TRICKETT via REUTERS"],
      "sourceMatches": []
    },
    {
      "name": "RexParser",
      "creditMatches": [".+/ Rex Features"],
      "sourceMatches": ["Rex Features", "REX/Shutterstock"]
    },
    {
      "name": "RonaldGrantParser",
      "creditMatches": ["www.ronaldgrantarchive.com", "Ronald Grant Archive"],
      "sourceMatches": []
    }
  ], 
  "supplierParsers": [
    "GettyXmp",   
    "GettyCredit",
    "Aap",        
    "ActionImages",
    "Alamy",       
    "AllStar",     
    "Ap",          
    "Barcroft",    
    "Bloomberg",   
    "Corbis",      
    "Epa",         
    "Pa",         
    "Reuters",     
    "Rex",         
    "RonaldGrant",
    "Afp",
    "Photographer" 
  ],
  "usageRights": [
    "NoRights",
    "Handout",
    "PrImage",
    "Screengrab",
    "SocialMedia",
    "Agency",
    "CommissionedAgency",
    "Chargeable",
    "Bylines",
    "StaffPhotographer",
    "ContractPhotographer",
    "CommissionedPhotographer",
    "CreativeCommons",
    "Pool",
    "CrownCopyright",
    "Obituary",
    "ContractIllustrator",
    "CommissionedIllustrator",
    "StaffIllustrator",
    "Composite",
    "PublicDomain"
  ],
  "supplierCostings": {
    "Rex Features": "free",
    "Alamy"       : "free",
    "Reuters"     : "free",
    "EPA"         : "free",
    "Getty Images": "free",
    "AFP"         : "free",
    "PA"          : "free"
  },
  "freeSuppliers": [
    "AAP",
    "Alamy",
    "Allstar Picture Library",
    "AP",
    "Barcroft Media",
    "Bloomberg",
    "Getty Images",
    "PA",
    "Reuters",
    "Rex Features",
    "Ronald Grant Archive",
    "Action Images",
    "Action Images via Reuters",
    "AFP"
  ],
  "suppliersCollectionExcl": {
    "Getty Images": [
      "Arnold Newman Collection",
      "360cities.net Editorial",
      "360cities.net RM",
      "age fotostock RM",
      "Alinari",
      "Arnold Newman Collection",
      "ASAblanca",
      "Barcroft Media",
      "Bloomberg",
      "Bob Thomas Sports Photography",
      "Carnegie Museum of Art",
      "Catwalking",
      "Contour",
      "Contour RA",
      "Corbis Premium Historical",
      "Editorial Specials",
      "Reportage Archive",
      "Gamma-Legends",
      "Genuine Japan Editorial Stills",
      "Genuine Japan Creative Stills",
      "George Steinmetz",
      "Getty Images Sport Classic",
      "Iconic Images",
      "Iconica",
      "Icon Sport",
      "Kyodo News Stills",
      "Lichfield Studios Limited",
      "Lonely Planet Images",
      "Lonely Planet RF",
      "Masters",
      "Major League Baseball Platinum",
      "Moment Select",
      "Mondadori Portfolio Premium",
      "National Geographic",
      "National Geographic RF",
      "National Geographic Creative",
      "National Geographic Magazines",
      "NBA Classic",
      "Neil Leifer Collection",
      "Newspix",
      "PA Images",
      "Papixs",
      "Paris Match Archive",
      "Paris Match Collection",
      "Pele 10",
      "Photonica",
      "Photonica World",
      "Popperfoto",
      "Popperfoto Creative",
      "Premium Archive",
      "Reportage Archive",
      "SAMURAI JAPAN",
      "Sports Illustrated",
      "Sports Illustrated Classic",
      "Sportsfile",
      "Sygma Premium",
      "Terry O'Neill",
      "The Asahi Shimbun Premium",
      "The LIFE Premium Collection",
      "ullstein bild Premium",
      "Ulrich Baumgarten",
      "VII Premium",
      "Vision Media",
      "Xinhua News Agency"
    ]
  }
}
```

</p>
</details> 

An extra parser for AFP has been added. A test is added for this case.

## Tested?
- [x] locally
- [ ] on TEST