### PR TITLE
show seconds in image upload and taken times

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -93,7 +93,7 @@
     <div class="image-info__group">
         <dl class="image-info__group--dl metadata-line">
             <dt class="image-info__group--dl__key metadata-line__key image-info__wrap" ng:if="ctrl.metadata.dateTaken">Taken on</dt>
-            <dd class="image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
+            <dd class="image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm:ss'}}</dd>
 
             <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng:if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
             <dd class="image-info__wrap image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.byline || ctrl.userCanEdit">
@@ -192,7 +192,7 @@
             <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">Uploaded</dt>
             <dd class="image-info__group--dl__value metadata-line__info">
                         <span class="metadata-line__info">
-                            {{ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm'}}
+                            {{ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm:ss'}}
                         </span>
             </dd>
 

--- a/kahuna/public/js/preview/image-large.html
+++ b/kahuna/public/js/preview/image-large.html
@@ -95,7 +95,7 @@
             <div class="bottom-bar__meta">
                 <span class="preview__upload-time">
                     {{ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
-                    {{ctrl.image.data.uploadTime | date:'HH:mm'}}
+                    {{ctrl.image.data.uploadTime | date:'HH:mm:ss'}}
                 </span>
 
                 <span class="bottom-bar__meta-item preview__has-crops"

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -88,7 +88,7 @@
         <div class="bottom-bar__meta">
             <span class="preview__upload-time">
                 {{::ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
-                {{::ctrl.image.data.uploadTime | date:'HH:mm'}}
+                {{::ctrl.image.data.uploadTime | date:'HH:mm:ss'}}
             </span>
 
             <span class="bottom-bar__meta-item preview__has-crops"


### PR DESCRIPTION
## What does this change?


## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
