### PR TITLE
store the original file name alongside the original image in aws as m…

### DIFF
--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -200,7 +200,8 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
     uploadRequest.mimeType,
     Map(
       "uploaded_by" -> uploadRequest.uploadedBy,
-      "upload_time" -> printDateTime(uploadRequest.uploadTime)
+      "upload_time" -> printDateTime(uploadRequest.uploadTime),
+      "file_name" -> uploadRequest.uploadInfo.filename.orNull
     ) ++ uploadRequest.identifiersMeta
   )
   def storeThumbnail(uploadRequest: UploadRequest, thumbFile: File) = store.storeThumbnail(


### PR DESCRIPTION
…etadata

## What does this change?

Store the original file name in metadata with in the image bucket in aws. This is because this info is just currently saved in ES, and so it would be good to have saved in case we need to re-ingest images for whatever reason (and potentially the ES index data is lost).
