### PR TITLE
IMAGEDAM-194: Add image pre-defined metadata fields

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -14,3 +14,42 @@
 .full-metadata-key {
   margin-right: 15px;
 }
+
+gr-add-meta {
+  display: flex;
+  height: 25px;
+}
+
+gr-add-meta:hover {
+  color: white;
+}
+
+gr-add-meta .small {
+  border: none;
+  padding: 0;
+}
+
+.gr-add-meta__form {
+}
+.gr-add-meta__form select {
+  width: 265px;
+}
+
+.gr-add-meta__form__input {
+  width: 265px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.gr-add-meta__form__buttons {
+  display: flex;
+}
+
+.gr-add-meta__form__buttons__button-cancel,
+.gr-add-label__form__buttons__button-save {
+  margin-left: 1px;
+}
+.image-info__heading--meta {
+  width: 94%;
+  float: left;
+}

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -4,7 +4,7 @@
       <dt class="metadata-line__key">Rights & restrictions</dt>
 
       <gr-usage-rights-editor ng-if="ctrl.showUsageRights" gr-usage-rights="[ctrl.usageRights]"
-                              gr-on-save="ctrl.showUsageRights = false" gr-on-cancel="ctrl.showUsageRights = false">
+        gr-on-save="ctrl.showUsageRights = false" gr-on-cancel="ctrl.showUsageRights = false">
       </gr-usage-rights-editor>
 
       <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
@@ -12,7 +12,8 @@
       </dd>
 
       <button data-cy="it-edit-usage-rights-button" ng-click="ctrl.showUsageRights = true"
-              ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights" class="image-info__edit">✎</button>
+        ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights" class="image-info__edit">✎
+      </button>
     </dl>
   </div>
   <div class="image-info">
@@ -30,22 +31,22 @@
     <dl>
       <div class="image-info__wrap" ng-if="ctrl.metadata.title">
         <button class="image-info__edit" ng-if="ctrl.userCanEdit" ng-click="titleEditForm.$show()"
-                ng-hide="titleEditForm.$visible">✎</button>
+          ng-hide="titleEditForm.$visible">✎</button>
         <dt class="metadata-line metadata-line__key">Title</dt>
         <dd class="image-info__title metadata-line__info" editable-text="ctrl.metadata.title"
-            ng-hide="titleEditForm.$visible" onbeforesave="ctrl.updateMetadataField('title', $data)" e:ng-class="{'image-info__editor--error': $error,
+          ng-hide="titleEditForm.$visible" onbeforesave="ctrl.updateMetadataField('title', $data)" e:ng-class="{'image-info__editor--error': $error,
                                'image-info__editor--saving': titleEditForm.$waiting,
                                'text-input': true}" e:form="titleEditForm">{{ctrl.metadata.title}}</dd>
       </div>
 
       <div data-cy="metadata-description" class="image-info__wrap metadata-line__info"
-           ng-if="ctrl.metadata.description || ctrl.userCanEdit">
+        ng-if="ctrl.metadata.description || ctrl.userCanEdit">
         <button data-cy="it-edit-description-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
-                ng-click="descriptionEditForm.$show()" ng-hide="descriptionEditForm.$visible">✎</button>
+          ng-click="descriptionEditForm.$show()" ng-hide="descriptionEditForm.$visible">✎</button>
         <dt class="metadata-line metadata-line__key">Description</dt>
         <dd class="image-info__description" editable-textarea="ctrl.metadata.description"
-            ng-hide="descriptionEditForm.$visible" onbeforesave="ctrl.updateMetadataField('description', $data)"
-            e:msd-elastic e:ng-class="{'image-info__editor--error': $error,
+          ng-hide="descriptionEditForm.$visible" onbeforesave="ctrl.updateMetadataField('description', $data)"
+          e:msd-elastic e:ng-class="{'image-info__editor--error': $error,
                                'image-info__editor--saving': descriptionEditForm.$waiting,
                                'text-input': true}" e:form="descriptionEditForm">
           {{ctrl.metadata.description || "Unknown (click ✎ to add)"}}</dd>
@@ -57,11 +58,11 @@
   <div class="image-info__group" ng-if="ctrl.metadata.specialInstructions">
     <dl class="image-info__wrap">
       <button class="image-info__edit" ng-if="ctrl.userCanEdit" ng-click="specialInstructionsEditForm.$show()"
-              ng-hide="specialInstructionsEditForm.$visible">✎</button>
+        ng-hide="specialInstructionsEditForm.$visible">✎</button>
       <dt class="metadata-line metadata-line__key">Special instructions</dt>
       <dd class="image-info__special-instructions" editable-textarea="ctrl.metadata.specialInstructions"
-          ng-hide="specialInstructionsEditForm.$visible"
-          onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)" e:msd-elastic e:ng-class="{'image-info__editor--error': $error,
+        ng-hide="specialInstructionsEditForm.$visible"
+        onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)" e:msd-elastic e:ng-class="{'image-info__editor--error': $error,
                            'image-info__editor--saving': specialInstructionsEditForm.$waiting,
                            'text-input': true}" e:form="specialInstructionsEditForm">
         {{ctrl.metadata.specialInstructions}}</dd>
@@ -77,13 +78,13 @@
         {{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm:ss'}}</dd>
 
       <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key"
-          ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
+        ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
       <dd data-cy="metadata-byline" class="image-info__wrap image-info__group--dl__value metadata-line__info"
-          ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
+        ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
         <button data-cy="it-edit-byline-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
-                ng-click="bylineEditForm.$show()" ng-hide="bylineEditForm.$visible">✎</button>
+          ng-click="bylineEditForm.$show()" ng-hide="bylineEditForm.$visible">✎</button>
         <span class="image-info__byline" editable-text="ctrl.metadata.byline" ng-hide="bylineEditForm.$visible"
-              onbeforesave="ctrl.updateMetadataField('byline', $data)" e:ng-class="{'image-info__editor--error': $error,
+          onbeforesave="ctrl.updateMetadataField('byline', $data)" e:ng-class="{'image-info__editor--error': $error,
                                          'image-info__editor--saving': bylineEditForm.$waiting,
                                          'text-input': true}" e:form="bylineEditForm">
 
@@ -97,15 +98,15 @@
       </dd>
 
       <dt ng-if="ctrl.metadata.credit || ctrl.userCanEdit"
-          class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
+        class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
       <dd data-cy="metadata-credit" ng-if="ctrl.metadata.credit || ctrl.userCanEdit"
-          class="image-info__wrap image-info__group--dl__value metadata-line__info">
+        class="image-info__wrap image-info__group--dl__value metadata-line__info">
         <button data-cy="it-edit-credit-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
-                ng-click="creditEditForm.$show()" ng-hide="creditEditForm.$visible">✎</button>
+          ng-click="creditEditForm.$show()" ng-hide="creditEditForm.$visible">✎</button>
 
         <span class="metadata-line__info" editable-text="ctrl.metadata.credit" ng-hide="creditEditForm.$visible"
-              e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
-              onbeforesave="ctrl.updateMetadataField('credit', $data)" e:ng-class="{'image-info__editor--error': $error,
+          e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
+          onbeforesave="ctrl.updateMetadataField('credit', $data)" e:ng-class="{'image-info__editor--error': $error,
                                          'image-info__editor--saving': creditEditForm.$waiting,
                                          'text-input': true}" e:form="creditEditForm">
 
@@ -137,13 +138,13 @@
 
 
       <dt ng-if="ctrl.metadata.copyright || ctrl.userCanEdit"
-          class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
+        class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
       <dd data-cy="metadata-copyright" ng-if="ctrl.metadata.copyright || ctrl.userCanEdit"
-          class="image-info__wrap image-info__group--dl__value metadata-line__info">
+        class="image-info__wrap image-info__group--dl__value metadata-line__info">
         <button data-cy="it-edit-copyright-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
-                ng-click="copyrightEditForm.$show()" ng-hide="copyrightEditForm.$visible">✎</button>
+          ng-click="copyrightEditForm.$show()" ng-hide="copyrightEditForm.$visible">✎</button>
         <span class="image-info__copyright" editable-text="ctrl.metadata.copyright" ng-hide="copyrightEditForm.$visible"
-              onbeforesave="ctrl.updateMetadataField('copyright', $data)" e:ng-class="{'image-info__editor--error': $error,
+          onbeforesave="ctrl.updateMetadataField('copyright', $data)" e:ng-class="{'image-info__editor--error': $error,
                                          'image-info__editor--saving': copyrightEditForm.$waiting,
                                          'text-input': true}" e:form="copyrightEditForm">
 
@@ -173,18 +174,18 @@
       </dd>
 
       <dt ng-if="ctrl.image.data.uploadInfo.filename"
-          class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        class="image-info__group--dl__key metadata-line__key image-info__wrap">
         Filename
       </dt>
       <dd ng-if="ctrl.image.data.uploadInfo.filename" class="image-info__group--dl__value metadata-line__info"
-          title="{{ctrl.image.data.uploadInfo.filename}}">
+        title="{{ctrl.image.data.uploadInfo.filename}}">
         <span class="metadata-line__info select-all-wrap">
           {{ctrl.image.data.uploadInfo.filename}}
         </span>
       </dd>
 
       <dt ng-if="ctrl.metadata.subjects.length > 0"
-          class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        class="image-info__group--dl__key metadata-line__key image-info__wrap">
         Subjects
       </dt>
       <dd ng-if="ctrl.metadata.subjects.length > 0" class="image-info__group--dl__value metadata-line__info">
@@ -198,7 +199,7 @@
       </dd>
 
       <dt ng:if="ctrl.metadata.peopleInImage.length > 0"
-          class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        class="image-info__group--dl__key metadata-line__key image-info__wrap">
         People
       </dt>
       <dd ng:if="ctrl.metadata.peopleInImage.length > 0" class="image-info__group--dl__value metadata-line__info">
@@ -206,7 +207,7 @@
           <span ng:repeat="person in ctrl.metadata.peopleInImage">
             <span class="metadata-line__info--nowrap">
               <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a><span
-              ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">,
+                ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">,
               </span>
             </span>
             <!--                        <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a>-->
@@ -217,6 +218,55 @@
       </dd>
     </dl>
   </div>
+
+  <div class="image-info">
+    <dl class="image-info__group image-info__wrap" ng-if="ctrl.displayMetadataFields()">
+      <dt class="image-info__heading image-info__heading--first flex-container image-info__heading--meta">
+        <span class="metadata-line__key flex-spacer">Add Metadata Field</span>
+      </dt>
+
+      <button ng-class="{'small': ctrl.grSmall}" ng-click="ctrl.addMetaFormActive = !ctrl.addMetaFormActive"
+        ng-disabled="ctrl.addingMetadata" gr-tooltip="Add metadata" gr-tooltip-position="left">
+        <gr-icon ng-class="{'spin': ctrl.addingMetadata}">add_box</gr-icon>
+        <span>
+          <span ng-show="ctrl.addingMetadata"></span>
+        </span>
+      </button>
+
+      <form class="gr-add-meta__form" ng-if="ctrl.addMetaFormActive"
+        ng-submit="ctrl.updateMetadataField(selectedMetadata, ctrl.metadataFieldValue)">
+
+        <select ng-model="selectedMetadata" ng-change="ctrl.selectChanged()">
+          <option ng-repeat="meta in ctrl.metadataFields" value="{{meta.value}}">{{meta.name}}</option>
+        </select>
+
+        <div ng-if="ctrl.itemSelected">
+          <gr-datalist class="job-info--editor__input">
+
+            <input type="text" class="text-input gr-add-meta__form__input show-no-error" placeholder="Metadata Value..."
+              required ng-model="ctrl.metadataFieldValue" ng-disabled="ctrl.addingMetadata" />
+          </gr-datalist>
+
+          <span class="gr-add-meta__form__buttons">
+
+            <button class="gr-add-meta__form__buttons__button-cancel button-cancel" type="button"
+              ng-click="ctrl.metadataFormReset()" title="cancel">
+              <gr-icon-label gr-icon="close"><span>Cancel</span></gr-icon-label>
+            </button>
+
+            <button data-cy="save-new-meta-button" class="gr-add-meta__form__buttons__button-save button-save"
+              type="submit" title="save new metadata" ng-disabled="ctrl.addingMetadata">
+              <gr-icon-label gr-icon="check">
+                <span>Save</span>
+              </gr-icon-label>
+            </button>
+
+          </span>
+        </div>
+      </form>
+    </dl>
+  </div>
+
   <!-- FIXME: iff has useful metadata -->
   <div class="image-info__group image-info__group--full-metadata">
     <button class="metadata-reveal" ng-click="metadataExpanded = !metadataExpanded">
@@ -227,13 +277,13 @@
 
     <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl full-metadata">
       <dl ng-repeat="(key, value) in ctrl.metadata" ng-if="ctrl.isUsefulMetadata(key)"
-          class="metadata__body image-info__group--dl">
+        class="metadata__body image-info__group--dl">
         <dd class="image-info__wrap image-info__group--dl__value metadata-line__info full-metadata-section">
           <button class="image-info__edit" ng-if="ctrl.userCanEdit" ng-click="metaEditForm.$show()"
-                  ng-hide="metaEditForm.$visible">✎
+            ng-hide="metaEditForm.$visible">✎
           </button>
           <span editable-text="value" ng-hide="metaEditForm.$visible"
-                onbeforesave="ctrl.updateMetadataField(key, $data)" e:ng-class="{'image-info__editor--error': $error,
+            onbeforesave="ctrl.updateMetadataField(key, $data)" e:ng-class="{'image-info__editor--error': $error,
                                            'image-info__editor--saving': metaEditForm.$waiting,
                                            'text-input': true}" e:form="metaEditForm">
 
@@ -266,8 +316,8 @@
       <span class="flex-spacer"></span>
       <span ng-if="ctrl.removingCollection === collection">Removing…</span>
       <button class="clickable" type="button" ng-click="ctrl.removeImageFromCollection(collection)"
-              ng-hide="ctrl.removingCollection === collection" gr-tooltip="Remove image from this collection"
-              gr-tooltip-position="top-left">
+        ng-hide="ctrl.removingCollection === collection" gr-tooltip="Remove image from this collection"
+        gr-tooltip-position="top-left">
         <gr-icon-label gr-icon="clear"></gr-icon-label>
       </button>
     </dd>

--- a/kahuna/webpack.config.dev.js
+++ b/kahuna/webpack.config.dev.js
@@ -5,5 +5,7 @@ module.exports = merge(shared,{
   mode: 'development',
   devServer: {
     publicPath: '/public/dist/',
+     hot: true,
+     watch: true
   },
 });


### PR DESCRIPTION
## What does this change?

- Add pre-defined metadata fields to image from UI


## How can success be measured?
- The user is presented with the option of metadata fields to chose from that are not already populated on a given image. 
- As a user with the appropriate permission/authority, I am able to update the metadata of a given image that has previously been ingested from any source 

## Screenshots (if applicable)
![Screenshot from 2020-11-16 16-28-03](https://user-images.githubusercontent.com/33189781/99264646-6a78bd80-2829-11eb-8e44-4908455f2092.png)
![Screenshot from 2020-11-16 16-29-48](https://user-images.githubusercontent.com/33189781/99264651-6c428100-2829-11eb-8469-8c076d3f06c8.png)
![Screenshot from 2020-11-16 16-30-03](https://user-images.githubusercontent.com/33189781/99264655-6cdb1780-2829-11eb-88dd-6c0157282b1b.png)



## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
