### PR TITLE
Feature/update full metadata

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -1,0 +1,16 @@
+.full-metadata {
+  margin-top: 5px;
+}
+
+.full-metadata-section {
+  display: inline-table;
+  width: 270px;
+}
+
+.full-metadata-section button {
+  left: 245px;
+}
+
+.full-metadata-key {
+  margin-right: 15px;
+}

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -225,11 +225,25 @@
       full metadata
     </button>
 
-    <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
+    <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl full-metadata">
       <dl ng-repeat="(key, value) in ctrl.metadata" ng-if="ctrl.isUsefulMetadata(key)"
           class="metadata__body image-info__group--dl">
-        <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
-        <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
+        <dd class="image-info__wrap image-info__group--dl__value metadata-line__info full-metadata-section">
+          <button class="image-info__edit" ng-if="ctrl.userCanEdit" ng-click="metaEditForm.$show()"
+                  ng-hide="metaEditForm.$visible">✎
+          </button>
+          <span editable-text="value" ng-hide="metaEditForm.$visible"
+                onbeforesave="ctrl.updateMetadataField(key, $data)" e:ng-class="{'image-info__editor--error': $error,
+                                           'image-info__editor--saving': metaEditForm.$waiting,
+                                           'text-input': true}" e:form="metaEditForm">
+
+            <span>
+              <span
+                class="full-metadata-key image-info__wrap image-info__group--dl__key metadata-line__key">{{key | spaceWords}}</span>
+              <span>{{value}}</span>
+            </span>
+          </span>
+        </dd>
       </dl>
       <dl ng-repeat="(key, value) in ctrl.identifiers" class="metadata__body image-info__group--dl">
         <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -1,352 +1,311 @@
 <div class="image-info">
-    <div class="image-info__group">
-        <dl class="image-info__wrap metadata-line image-info__usage-rights">
-            <dt class="metadata-line__key">Rights & restrictions</dt>
+  <div class="image-info__group">
+    <dl class="image-info__wrap metadata-line image-info__usage-rights">
+      <dt class="metadata-line__key">Rights & restrictions</dt>
 
-            <gr-usage-rights-editor
-                ng-if="ctrl.showUsageRights"
-                gr-usage-rights="[ctrl.usageRights]"
-                gr-on-save="ctrl.showUsageRights = false"
-                gr-on-cancel="ctrl.showUsageRights = false">
-            </gr-usage-rights-editor>
+      <gr-usage-rights-editor ng-if="ctrl.showUsageRights" gr-usage-rights="[ctrl.usageRights]"
+                              gr-on-save="ctrl.showUsageRights = false" gr-on-cancel="ctrl.showUsageRights = false">
+      </gr-usage-rights-editor>
 
-            <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
-                {{ctrl.usageCategory || 'None'}}
-            </dd>
+      <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
+        {{ctrl.usageCategory || 'None'}}
+      </dd>
 
-            <button
-                data-cy="it-edit-usage-rights-button"
-                ng-click="ctrl.showUsageRights = true"
-                ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights"
-                class="image-info__edit">✎</button>
-        </dl>
-    </div>
-    <div class="image-info">
+      <button data-cy="it-edit-usage-rights-button" ng-click="ctrl.showUsageRights = true"
+              ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights" class="image-info__edit">✎</button>
+    </dl>
+  </div>
+  <div class="image-info">
     <dl class="image-info__group image-info__wrap" ng-if="ctrl.displayLeases()">
-        <dt class="image-info__heading image-info__heading--first flex-container image-info__heading--lease">
-            <span class="metadata-line__key flex-spacer">Leases</span>
-        </dt>
+      <dt class="image-info__heading image-info__heading--first flex-container image-info__heading--lease">
+        <span class="metadata-line__key flex-spacer">Leases</span>
+      </dt>
 
-        <gr-leases
-            gr-images="[ctrl.image]"
-            gr-user-can-edit="ctrl.userCanEdit">
-        </gr-leases>
+      <gr-leases gr-images="[ctrl.image]" gr-user-can-edit="ctrl.userCanEdit">
+      </gr-leases>
     </dl>
-</div>
+  </div>
 
-    <div class="image-info__group">
-        <dl>
-            <div class="image-info__wrap" ng-if="ctrl.metadata.title">
-                <button class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="titleEditForm.$show()"
-                        ng-hide="titleEditForm.$visible">✎</button>
-                <dt class="metadata-line metadata-line__key">Title</dt>
-                <dd class="image-info__title metadata-line__info"
-                    editable-text="ctrl.metadata.title"
-                    ng-hide="titleEditForm.$visible"
-                    onbeforesave="ctrl.updateMetadataField('title', $data)"
-                    e:ng-class="{'image-info__editor--error': $error,
-                                 'image-info__editor--saving': titleEditForm.$waiting,
-                                 'text-input': true}"
-                    e:form="titleEditForm">{{ctrl.metadata.title}}</dd>
-            </div>
+  <div class="image-info__group">
+    <dl>
+      <div class="image-info__wrap" ng-if="ctrl.metadata.title">
+        <button class="image-info__edit" ng-if="ctrl.userCanEdit" ng-click="titleEditForm.$show()"
+                ng-hide="titleEditForm.$visible">✎</button>
+        <dt class="metadata-line metadata-line__key">Title</dt>
+        <dd class="image-info__title metadata-line__info" editable-text="ctrl.metadata.title"
+            ng-hide="titleEditForm.$visible" onbeforesave="ctrl.updateMetadataField('title', $data)" e:ng-class="{'image-info__editor--error': $error,
+                               'image-info__editor--saving': titleEditForm.$waiting,
+                               'text-input': true}" e:form="titleEditForm">{{ctrl.metadata.title}}</dd>
+      </div>
 
-            <div data-cy="metadata-description" class="image-info__wrap metadata-line__info" ng-if="ctrl.metadata.description || ctrl.userCanEdit">
-                <button data-cy="it-edit-description-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="descriptionEditForm.$show()"
-                        ng-hide="descriptionEditForm.$visible">✎</button>
-                <dt class="metadata-line metadata-line__key">Description</dt>
-                <dd class="image-info__description"
-                    editable-textarea="ctrl.metadata.description"
-                    ng-hide="descriptionEditForm.$visible"
-                    onbeforesave="ctrl.updateMetadataField('description', $data)"
-                    e:msd-elastic
-                    e:ng-class="{'image-info__editor--error': $error,
-                                 'image-info__editor--saving': descriptionEditForm.$waiting,
-                                 'text-input': true}"
-                    e:form="descriptionEditForm">{{ctrl.metadata.description || "Unknown (click ✎ to add)"}}</dd>
-            </div>
-            <gr-description-warning description="ctrl.metadata.description"></gr-description-warning>
-        </dl>
-    </div>
+      <div data-cy="metadata-description" class="image-info__wrap metadata-line__info"
+           ng-if="ctrl.metadata.description || ctrl.userCanEdit">
+        <button data-cy="it-edit-description-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
+                ng-click="descriptionEditForm.$show()" ng-hide="descriptionEditForm.$visible">✎</button>
+        <dt class="metadata-line metadata-line__key">Description</dt>
+        <dd class="image-info__description" editable-textarea="ctrl.metadata.description"
+            ng-hide="descriptionEditForm.$visible" onbeforesave="ctrl.updateMetadataField('description', $data)"
+            e:msd-elastic e:ng-class="{'image-info__editor--error': $error,
+                               'image-info__editor--saving': descriptionEditForm.$waiting,
+                               'text-input': true}" e:form="descriptionEditForm">
+          {{ctrl.metadata.description || "Unknown (click ✎ to add)"}}</dd>
+      </div>
+      <gr-description-warning description="ctrl.metadata.description"></gr-description-warning>
+    </dl>
+  </div>
 
-    <div class="image-info__group" ng-if="ctrl.metadata.specialInstructions">
-        <dl class="image-info__wrap">
-            <button class="image-info__edit"
-                    ng-if="ctrl.userCanEdit"
-                    ng-click="specialInstructionsEditForm.$show()"
-                    ng-hide="specialInstructionsEditForm.$visible">✎</button>
-            <dt class="metadata-line metadata-line__key">Special instructions</dt>
-            <dd class="image-info__special-instructions"
-                editable-textarea="ctrl.metadata.specialInstructions"
-                ng-hide="specialInstructionsEditForm.$visible"
-                onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
-                e:msd-elastic
-                e:ng-class="{'image-info__editor--error': $error,
-                             'image-info__editor--saving': specialInstructionsEditForm.$waiting,
-                             'text-input': true}"
-                e:form="specialInstructionsEditForm">{{ctrl.metadata.specialInstructions}}</dd>
-        </dl>
-    </div>
+  <div class="image-info__group" ng-if="ctrl.metadata.specialInstructions">
+    <dl class="image-info__wrap">
+      <button class="image-info__edit" ng-if="ctrl.userCanEdit" ng-click="specialInstructionsEditForm.$show()"
+              ng-hide="specialInstructionsEditForm.$visible">✎</button>
+      <dt class="metadata-line metadata-line__key">Special instructions</dt>
+      <dd class="image-info__special-instructions" editable-textarea="ctrl.metadata.specialInstructions"
+          ng-hide="specialInstructionsEditForm.$visible"
+          onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)" e:msd-elastic e:ng-class="{'image-info__editor--error': $error,
+                           'image-info__editor--saving': specialInstructionsEditForm.$waiting,
+                           'text-input': true}" e:form="specialInstructionsEditForm">
+        {{ctrl.metadata.specialInstructions}}</dd>
+    </dl>
+  </div>
 
-    <div class="image-info__group">
-        <dl class="image-info__group--dl metadata-line">
+  <div class="image-info__group">
+    <dl class="image-info__group--dl metadata-line">
 
-            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap" ng:if="ctrl.metadata.dateTaken">Taken on</dt>
-            <dd class="image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm:ss'}}</dd>
+      <dt class="image-info__group--dl__key metadata-line__key image-info__wrap" ng:if="ctrl.metadata.dateTaken">Taken
+        on</dt>
+      <dd class="image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.dateTaken">
+        {{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm:ss'}}</dd>
 
-            <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
-            <dd data-cy="metadata-byline" class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
-                <button data-cy="it-edit-byline-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="bylineEditForm.$show()"
-                        ng-hide="bylineEditForm.$visible"
-                    >✎</button>
-                        <span class="image-info__byline"
-                              editable-text="ctrl.metadata.byline"
-                              ng-hide="bylineEditForm.$visible"
-                              onbeforesave="ctrl.updateMetadataField('byline', $data)"
-                              e:ng-class="{'image-info__editor--error': $error,
-                                           'image-info__editor--saving': bylineEditForm.$waiting,
-                                           'text-input': true}"
-                              e:form="bylineEditForm">
+      <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key"
+          ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
+      <dd data-cy="metadata-byline" class="image-info__wrap image-info__group--dl__value metadata-line__info"
+          ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
+        <button data-cy="it-edit-byline-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
+                ng-click="bylineEditForm.$show()" ng-hide="bylineEditForm.$visible">✎</button>
+        <span class="image-info__byline" editable-text="ctrl.metadata.byline" ng-hide="bylineEditForm.$visible"
+              onbeforesave="ctrl.updateMetadataField('byline', $data)" e:ng-class="{'image-info__editor--error': $error,
+                                         'image-info__editor--saving': bylineEditForm.$waiting,
+                                         'text-input': true}" e:form="bylineEditForm">
 
-                            <span ng-if="ctrl.metadata.byline">
-                                <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
-                            </span>
-                            <span ng-if="! ctrl.metadata.byline">
-                                Unknown (click ✎ to add)
-                            </span>
-                        </span>
-            </dd>
+          <span ng-if="ctrl.metadata.byline">
+            <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+          </span>
+          <span ng-if="! ctrl.metadata.byline">
+            Unknown (click ✎ to add)
+          </span>
+        </span>
+      </dd>
 
-            <dt ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
-            <dd data-cy="metadata-credit" ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
-                <button data-cy="it-edit-credit-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="creditEditForm.$show()"
-                        ng-hide="creditEditForm.$visible"
-                    >✎</button>
+      <dt ng-if="ctrl.metadata.credit || ctrl.userCanEdit"
+          class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
+      <dd data-cy="metadata-credit" ng-if="ctrl.metadata.credit || ctrl.userCanEdit"
+          class="image-info__wrap image-info__group--dl__value metadata-line__info">
+        <button data-cy="it-edit-credit-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
+                ng-click="creditEditForm.$show()" ng-hide="creditEditForm.$visible">✎</button>
 
-                        <span class="metadata-line__info"
-                              editable-text="ctrl.metadata.credit"
-                              ng-hide="creditEditForm.$visible"
-                              e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
-                              onbeforesave="ctrl.updateMetadataField('credit', $data)"
-                              e:ng-class="{'image-info__editor--error': $error,
-                                           'image-info__editor--saving': creditEditForm.$waiting,
-                                           'text-input': true}"
-                              e:form="creditEditForm">
+        <span class="metadata-line__info" editable-text="ctrl.metadata.credit" ng-hide="creditEditForm.$visible"
+              e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
+              onbeforesave="ctrl.updateMetadataField('credit', $data)" e:ng-class="{'image-info__editor--error': $error,
+                                         'image-info__editor--saving': creditEditForm.$waiting,
+                                         'text-input': true}" e:form="creditEditForm">
 
-                            <span ng-if="ctrl.metadata.credit">
-                                <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
-                            </span>
-                            <span ng-if="! ctrl.metadata.credit">
-                                Unknown (click ✎ to add)
-                            </span>
-                        </span>
-            </dd>
+          <span ng-if="ctrl.metadata.credit">
+            <a
+              ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+          </span>
+          <span ng-if="! ctrl.metadata.credit">
+            Unknown (click ✎ to add)
+          </span>
+        </span>
+      </dd>
 
 
-            <dt ng-if="ctrl.hasLocationInformation" class="image-info__group--dl__key metadata-line__key image-info__wrap">Location</dt>
-            <dd ng-if="ctrl.hasLocationInformation" class="image-info__group--dl__value metadata-line__info">
-                <span ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
-                    <span class="metadata-line__info">
-                        <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">
-                            {{ctrl.metadata[prop]}}
-                        </a>
-                    </span>
-                    <span ng-if="! $last">
-                        ,
-                    </span>
-                </span>
-            </dd>
-
-
-            <dt ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
-            <dd data-cy="metadata-copyright" ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
-                <button data-cy="it-edit-copyright-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="copyrightEditForm.$show()"
-                        ng-hide="copyrightEditForm.$visible"
-                    >✎</button>
-                        <span class="image-info__copyright"
-                              editable-text="ctrl.metadata.copyright"
-                              ng-hide="copyrightEditForm.$visible"
-                              onbeforesave="ctrl.updateMetadataField('copyright', $data)"
-                              e:ng-class="{'image-info__editor--error': $error,
-                                           'image-info__editor--saving': copyrightEditForm.$waiting,
-                                           'text-input': true}"
-                              e:form="copyrightEditForm">
-
-                            <span ng-if="ctrl.metadata.copyright">
-                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
-                            </span>
-                            <span ng-if="! ctrl.metadata.copyright">
-                                Unknown (click ✎ to add)
-                            </span>
-                        </span>
-            </dd>
-
-            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">Uploaded</dt>
-            <dd class="image-info__group--dl__value metadata-line__info">
-                        <span class="metadata-line__info">
-                            {{ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm:ss'}}
-                        </span>
-            </dd>
-
-            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">Uploader</dt>
-            <dd class="image-info__group--dl__value metadata-line__info">
-                        <span class="metadata-line__info">
-                            <a ui-sref="search.results({query: (ctrl.image.data.uploadedBy | queryFilter:'uploader')})">{{ctrl.image.data.uploadedBy | stripEmailDomain}}</a>
-                        </span>
-            </dd>
-
-            <dt ng-if="ctrl.image.data.uploadInfo.filename"
-                class="image-info__group--dl__key metadata-line__key image-info__wrap">
-                Filename
-            </dt>
-            <dd ng-if="ctrl.image.data.uploadInfo.filename"
-                class="image-info__group--dl__value metadata-line__info"
-                title="{{ctrl.image.data.uploadInfo.filename}}">
-                        <span class="metadata-line__info select-all-wrap">
-                            {{ctrl.image.data.uploadInfo.filename}}
-                        </span>
-            </dd>
-
-            <dt ng-if="ctrl.metadata.subjects.length > 0"
-                class="image-info__group--dl__key metadata-line__key image-info__wrap">
-                Subjects
-            </dt>
-            <dd ng-if="ctrl.metadata.subjects.length > 0"
-                class="image-info__group--dl__value metadata-line__info">
-                <span class="metadata-line__info">
-                    <span ng-repeat="subject in ctrl.metadata.subjects">
-                        <a ui-sref="search.results({query: (subject | queryFilter:'subject')})">
-                            {{subject}}
-                        </a>
-                    </span>
-                </span>
-            </dd>
-
-            <dt ng:if="ctrl.metadata.peopleInImage.length > 0"
-                class="image-info__group--dl__key metadata-line__key image-info__wrap">
-                People
-            </dt>
-            <dd ng:if="ctrl.metadata.peopleInImage.length > 0"
-                class="image-info__group--dl__value metadata-line__info">
-                <span class="metadata-line__info">
-                    <span ng:repeat="person in ctrl.metadata.peopleInImage">
-                      <span class="metadata-line__info--nowrap">
-                        <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a><span ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">, </span>
-                      </span>
-<!--                        <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a>-->
-<!--                        <span ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">, </span>-->
-
-                    </span>
-                </span>
-            </dd>
-        </dl>
-    </div>
-    <!-- FIXME: iff has useful metadata -->
-    <div class="image-info__group image-info__group--full-metadata">
-        <button class="metadata-reveal"
-                ng-click="metadataExpanded = !metadataExpanded">
-            <span ng-hide="metadataExpanded">▸ Show</span>
-            <span ng-show="metadataExpanded">▾ Hide</span>
-            full metadata
-        </button>
-
-        <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
-            <dl ng-repeat="(key, value) in ctrl.metadata" ng-if="ctrl.isUsefulMetadata(key)" class="metadata__body image-info__group--dl">
-                <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
-                <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
-            </dl>
-            <dl ng-repeat="(key, value) in ctrl.identifiers" class="metadata__body image-info__group--dl">
-                <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
-                <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
-            </dl>
-        </div>
-    </div>
-</div>
-
-<div class="image-info">
-    <dl class="image-info__group">
-        <dt class="flex-container">
-            <span class="metadata-line__key  flex-spacer">Collections</span>
-            <gr-collection-overlay image="ctrl.image"></gr-collection-overlay>
-        </dt>
-        <dd class="metadata-line__info flex-container"
-            ng-repeat="collection in ctrl.image.data.collections">
-            <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})">
-                {{collection.data.path.join(' ▸ ')}}
+      <dt ng-if="ctrl.hasLocationInformation" class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        Location</dt>
+      <dd ng-if="ctrl.hasLocationInformation" class="image-info__group--dl__value metadata-line__info">
+        <span ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
+          <span class="metadata-line__info">
+            <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">
+              {{ctrl.metadata[prop]}}
             </a>
-            <span class="flex-spacer"></span>
-            <span ng-if="ctrl.removingCollection === collection">Removing…</span>
-            <button class="clickable" type="button"
-                    ng-click="ctrl.removeImageFromCollection(collection)"
-                    ng-hide="ctrl.removingCollection === collection"
-                    gr-tooltip="Remove image from this collection"
-                    gr-tooltip-position="top-left">
-                <gr-icon-label gr-icon="clear"></gr-icon-label>
-            </button>
-        </dd>
-    </dl>
-</div>
+          </span>
+          <span ng-if="! $last">
+            ,
+          </span>
+        </span>
+      </dd>
 
-<div class="image-info">
-    <dl class="image-info__group image-info__wrap">
-        <dt class="image-info__heading image-info__heading--first flex-container">
-            <span class="flex-spacer">Labels</span>
-            <gr-add-label gr-small="true" images="[ctrl.image]" ng-blur="ctrl.cancel"></gr-add-label>
-        </dt>
-        <dd class="image-info__group--fixed-panel image-info__wrap">
-            <ui-labeller image="ctrl.image"></ui-labeller>
-        </dd>
-    </dl>
-</div>
 
-<div class="image-info">
-    <div class="image-info__group">
-        <dl class="image-info__wrap">
-            <dt class="metadata-line metadata-line__key">Photoshoot</dt>
-            <dd class="metadata-line__info">
-                <gr-photoshoot images="[ctrl.image]"></gr-photoshoot>
-            </dd>
-        </dl>
+      <dt ng-if="ctrl.metadata.copyright || ctrl.userCanEdit"
+          class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
+      <dd data-cy="metadata-copyright" ng-if="ctrl.metadata.copyright || ctrl.userCanEdit"
+          class="image-info__wrap image-info__group--dl__value metadata-line__info">
+        <button data-cy="it-edit-copyright-button" class="image-info__edit" ng-if="ctrl.userCanEdit"
+                ng-click="copyrightEditForm.$show()" ng-hide="copyrightEditForm.$visible">✎</button>
+        <span class="image-info__copyright" editable-text="ctrl.metadata.copyright" ng-hide="copyrightEditForm.$visible"
+              onbeforesave="ctrl.updateMetadataField('copyright', $data)" e:ng-class="{'image-info__editor--error': $error,
+                                         'image-info__editor--saving': copyrightEditForm.$waiting,
+                                         'text-input': true}" e:form="copyrightEditForm">
+
+          <span ng-if="ctrl.metadata.copyright">
+            <a
+              ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
+          </span>
+          <span ng-if="! ctrl.metadata.copyright">
+            Unknown (click ✎ to add)
+          </span>
+        </span>
+      </dd>
+
+      <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">Uploaded</dt>
+      <dd class="image-info__group--dl__value metadata-line__info">
+        <span class="metadata-line__info">
+          {{ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm:ss'}}
+        </span>
+      </dd>
+
+      <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">Uploader</dt>
+      <dd class="image-info__group--dl__value metadata-line__info">
+        <span class="metadata-line__info">
+          <a
+            ui-sref="search.results({query: (ctrl.image.data.uploadedBy | queryFilter:'uploader')})">{{ctrl.image.data.uploadedBy | stripEmailDomain}}</a>
+        </span>
+      </dd>
+
+      <dt ng-if="ctrl.image.data.uploadInfo.filename"
+          class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        Filename
+      </dt>
+      <dd ng-if="ctrl.image.data.uploadInfo.filename" class="image-info__group--dl__value metadata-line__info"
+          title="{{ctrl.image.data.uploadInfo.filename}}">
+        <span class="metadata-line__info select-all-wrap">
+          {{ctrl.image.data.uploadInfo.filename}}
+        </span>
+      </dd>
+
+      <dt ng-if="ctrl.metadata.subjects.length > 0"
+          class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        Subjects
+      </dt>
+      <dd ng-if="ctrl.metadata.subjects.length > 0" class="image-info__group--dl__value metadata-line__info">
+        <span class="metadata-line__info">
+          <span ng-repeat="subject in ctrl.metadata.subjects">
+            <a ui-sref="search.results({query: (subject | queryFilter:'subject')})">
+              {{subject}}
+            </a>
+          </span>
+        </span>
+      </dd>
+
+      <dt ng:if="ctrl.metadata.peopleInImage.length > 0"
+          class="image-info__group--dl__key metadata-line__key image-info__wrap">
+        People
+      </dt>
+      <dd ng:if="ctrl.metadata.peopleInImage.length > 0" class="image-info__group--dl__value metadata-line__info">
+        <span class="metadata-line__info">
+          <span ng:repeat="person in ctrl.metadata.peopleInImage">
+            <span class="metadata-line__info--nowrap">
+              <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a><span
+              ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">,
+              </span>
+            </span>
+            <!--                        <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a>-->
+            <!--                        <span ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">, </span>-->
+
+          </span>
+        </span>
+      </dd>
+    </dl>
+  </div>
+  <!-- FIXME: iff has useful metadata -->
+  <div class="image-info__group image-info__group--full-metadata">
+    <button class="metadata-reveal" ng-click="metadataExpanded = !metadataExpanded">
+      <span ng-hide="metadataExpanded">▸ Show</span>
+      <span ng-show="metadataExpanded">▾ Hide</span>
+      full metadata
+    </button>
+
+    <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
+      <dl ng-repeat="(key, value) in ctrl.metadata" ng-if="ctrl.isUsefulMetadata(key)"
+          class="metadata__body image-info__group--dl">
+        <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
+        <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
+      </dl>
+      <dl ng-repeat="(key, value) in ctrl.identifiers" class="metadata__body image-info__group--dl">
+        <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
+        <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
+      </dl>
     </div>
+  </div>
 </div>
 
 <div class="image-info">
-    <div class="image-info__group">
-        <dl class="image-info__wrap">
-            <dt class="metadata-line metadata-line__key">Syndication Rights (from RCS)</dt>
-            <dd class="metadata-line__info">
-                <gr-syndication-rights image="ctrl.image"></gr-syndication-rights>
-            </dd>
-        </dl>
-    </div>
+  <dl class="image-info__group">
+    <dt class="flex-container">
+      <span class="metadata-line__key  flex-spacer">Collections</span>
+      <gr-collection-overlay image="ctrl.image"></gr-collection-overlay>
+    </dt>
+    <dd class="metadata-line__info flex-container" ng-repeat="collection in ctrl.image.data.collections">
+      <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})">
+        {{collection.data.path.join(' ▸ ')}}
+      </a>
+      <span class="flex-spacer"></span>
+      <span ng-if="ctrl.removingCollection === collection">Removing…</span>
+      <button class="clickable" type="button" ng-click="ctrl.removeImageFromCollection(collection)"
+              ng-hide="ctrl.removingCollection === collection" gr-tooltip="Remove image from this collection"
+              gr-tooltip-position="top-left">
+        <gr-icon-label gr-icon="clear"></gr-icon-label>
+      </button>
+    </dd>
+  </dl>
 </div>
 
 <div class="image-info">
-    <dl class="image-info__group image-info__wrap" ng-if="ctrl.metadata.keywords.length > 0">
-        <dt class="image-info__heading image-info__wrap">Keywords</dt>
-        <dd class="image-info__keywords">
-            <ul>
-                <li class="image-info__keyword"
-                    ng-repeat="keyword in ctrl.metadata.keywords track by $index">
-                    <a ui-sref="search.results({query: (keyword | queryFilter:'keyword')})">
-                        {{keyword}}
-                    </a>
-                </li>
-            </ul>
-        </dd>
+  <dl class="image-info__group image-info__wrap">
+    <dt class="image-info__heading image-info__heading--first flex-container">
+      <span class="flex-spacer">Labels</span>
+      <gr-add-label gr-small="true" images="[ctrl.image]" ng-blur="ctrl.cancel"></gr-add-label>
+    </dt>
+    <dd class="image-info__group--fixed-panel image-info__wrap">
+      <ui-labeller image="ctrl.image"></ui-labeller>
+    </dd>
+  </dl>
+</div>
+
+<div class="image-info">
+  <div class="image-info__group">
+    <dl class="image-info__wrap">
+      <dt class="metadata-line metadata-line__key">Photoshoot</dt>
+      <dd class="metadata-line__info">
+        <gr-photoshoot images="[ctrl.image]"></gr-photoshoot>
+      </dd>
     </dl>
+  </div>
+</div>
+
+<div class="image-info">
+  <div class="image-info__group">
+    <dl class="image-info__wrap">
+      <dt class="metadata-line metadata-line__key">Syndication Rights (from RCS)</dt>
+      <dd class="metadata-line__info">
+        <gr-syndication-rights image="ctrl.image"></gr-syndication-rights>
+      </dd>
+    </dl>
+  </div>
+</div>
+
+<div class="image-info">
+  <dl class="image-info__group image-info__wrap" ng-if="ctrl.metadata.keywords.length > 0">
+    <dt class="image-info__heading image-info__wrap">Keywords</dt>
+    <dd class="image-info__keywords">
+      <ul>
+        <li class="image-info__keyword" ng-repeat="keyword in ctrl.metadata.keywords track by $index">
+          <a ui-sref="search.results({query: (keyword | queryFilter:'keyword')})">
+            {{keyword}}
+          </a>
+        </li>
+      </ul>
+    </dd>
+  </dl>
 </div>
 <gr-display-crops gr-small="true" crops="ctrl.image.allCrops"></gr-display-crops>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -4,6 +4,7 @@ import template from './gr-image-metadata.html';
 
 import '../../image/service';
 import '../../edits/service';
+import './gr-image-metadata.css';
 import '../gr-description-warning/gr-description-warning';
 
 export const module = angular.module('gr.imageMetadata', [


### PR DESCRIPTION
## What does this change?
Update image metadata in the full metadata section

## How can success be measured?
As a user with the appropriate permission/authority, I am able to update the metadata of a given image that laying into the full metadata section

## Screenshots (if applicable)
![Screenshot from 2020-11-18 12-48-56](https://user-images.githubusercontent.com/33189781/99521097-a1bbab80-299c-11eb-8595-e69f13cbcf90.png)
![Screenshot from 2020-11-18 12-49-35](https://user-images.githubusercontent.com/33189781/99521092-a1231500-299c-11eb-97e4-7153b3597d4a.png)
![Screenshot from 2020-11-18 12-49-57](https://user-images.githubusercontent.com/33189781/99521087-9ff1e800-299c-11eb-8252-243ca3dbf237.png)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
