### PR TITLE
Feature/scanner notification

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
@@ -66,14 +66,14 @@ abstract class SqsMessageConsumer(queueUrl: String, config: CommonConfig, metric
   private def deleteOnSuccess(msg: SQSMessage)(f: Future[Any]): Unit =
     f.foreach { _ => deleteMessage(msg) }
 
-  private def getMessages(waitTime: Int, maxMessages: Int): Seq[SQSMessage] =
+  def getMessages(waitTime: Int, maxMessages: Int): Seq[SQSMessage] =
     client.receiveMessage(
       new ReceiveMessageRequest(queueUrl)
         .withWaitTimeSeconds(waitTime)
         .withMaxNumberOfMessages(maxMessages)
     ).getMessages.asScala.toList
 
-  private def extractSNSMessage(sqsMessage: SQSMessage): Option[SNSMessage] =
+   def extractSNSMessage(sqsMessage: SQSMessage): Option[SNSMessage] =
     Json.fromJson[SNSMessage](Json.parse(sqsMessage.getBody)) <| logParseErrors |> (_.asOpt)
 
   private def deleteMessage(message: SQSMessage): Unit =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
@@ -76,7 +76,7 @@ abstract class SqsMessageConsumer(queueUrl: String, config: CommonConfig, metric
    def extractSNSMessage(sqsMessage: SQSMessage): Option[SNSMessage] =
     Json.fromJson[SNSMessage](Json.parse(sqsMessage.getBody)) <| logParseErrors |> (_.asOpt)
 
-  private def deleteMessage(message: SQSMessage): Unit =
+  def deleteMessage(message: SQSMessage): Unit =
     client.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle))
 }
 

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -137,6 +137,16 @@ Resources:
         Protocol: sqs
   IndexedImageMetadataQueue:
     Type: AWS::SQS::Queue
+
+  VirustScannerTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+        - Endpoint: !GetAtt 'VirusScannerStatusQueue.Arn'
+          Protocol: sqs
+  VirusScannerStatusQueue:
+    Type: AWS::SQS::Queue
+
   UsageRecordTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/dev/script/generate-dot-properties/service-config.js
+++ b/dev/script/generate-dot-properties/service-config.js
@@ -137,6 +137,7 @@ function getMediaApiConfig(config) {
         |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |image.record.download=false
+        |scanner.sqs.queue.url=${config.coreStackProps.VirusScannerStatusQueue.replace("http://localhost:4576", `https://localstack.media.${config.DOMAIN}`)}
         |`;
 }
 

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -16,6 +16,7 @@
     "javascript-detect-element-resize": "^0.5.3",
     "jszip": "2.6.0",
     "moment": "^2.9.0",
+    "ng-event-source": "^1.0.14",
     "panda-session": "0.1.6",
     "pandular": "0.1.6",
     "pikaday": "^1.3.2",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -16,7 +16,6 @@
     "javascript-detect-element-resize": "^0.5.3",
     "jszip": "2.6.0",
     "moment": "^2.9.0",
-    "ng-event-source": "^1.0.14",
     "panda-session": "0.1.6",
     "pandular": "0.1.6",
     "pikaday": "^1.3.2",

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -66,6 +66,11 @@ mediaApi.factory('mediaApi',
         return root.follow('image', {id: id}).get();
     }
 
+    function createResource(endpoint) {
+        const uri = mediaApiUri + endpoint
+        return client.resource(uri);
+    }
+
     function getSession() {
         // TODO: workout how we might be able to memoize this function but still
         // play nice with changes that might occur in the API (cache-header?).
@@ -92,6 +97,7 @@ mediaApi.factory('mediaApi',
         root,
         search,
         find,
+        createResource,
         getSession,
         metadataSearch,
         labelSearch,

--- a/kahuna/public/js/upload/jobs/upload-jobs.css
+++ b/kahuna/public/js/upload/jobs/upload-jobs.css
@@ -1,0 +1,21 @@
+.result-scanner {
+  position: absolute;
+  width: 246px;
+  text-align: center;
+  margin-top: 15px;
+  z-index: 1;
+  color: #00adee;
+}
+.result-scanner-negative {
+    color: #09B73C;
+
+    -webkit-transition: opacity 5s ease-in-out;
+    -moz-transition: opacity 5s ease-in-out;
+    -ms-transition: opacity 5s ease-in-out;
+    -o-transition: opacity 5s ease-in-out;
+     opacity: 0;
+}
+
+.result-scanner-positive {
+   color: red;
+}

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -1,6 +1,7 @@
 <ul>
     <li ng-repeat="job in ctrl.jobs | orderBy: 'name'"  class="upload-result">
 
+      <span id="{{job.name}}" class="result-scanner result-editor__save-status" >Scanning</span>
         <div ng-if="!job.image"
              class="job-uploading">
 
@@ -16,7 +17,7 @@
                         <div class="bottom-bar__actions"></div>
                     </div>
                 </div>
-                <div id="{{job.name}}" class="job-status status"
+                <div class="job-status status"
                      ng-class="{
                          'status--invalid': job.status === 'upload error',
                          'status--valid':   job.status === 'uploaded'

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -16,7 +16,7 @@
                         <div class="bottom-bar__actions"></div>
                     </div>
                 </div>
-                <div class="job-status status"
+                <div id="{{job.name}}" class="job-status status"
                      ng-class="{
                          'status--invalid': job.status === 'upload error',
                          'status--valid':   job.status === 'uploaded'

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -1,6 +1,8 @@
 import angular from "angular";
 import { EventSourcePolyfill } from "ng-event-source";
 
+import "./upload-jobs.css"
+
 import template from "./upload-jobs.html";
 import "../../preview/image";
 import "../../components/gr-delete-image/gr-delete-image";
@@ -59,14 +61,12 @@ jobs.controller("UploadJobsCtrl", [
         const data = JSON.parse(msg.data);
         const statusDiv = document.getElementById(data.metadata.file_name);
         if (data.scan_result === "POSITIVE") {
-          statusDiv.classList.add("status--invalid");
-          statusDiv.classList.remove("status--valid");
-          statusDiv.innerHTML = "file is infected with a virus";
+          statusDiv.classList.add("result-scanner-positive");
+          statusDiv.innerHTML = "file is infected with a virus!";
         }
         if (data.scan_result === "NEGATIVE") {
-          statusDiv.classList.remove("status--invalid");
-          statusDiv.classList.add("status--valid");
-          statusDiv.innerHTML = "no threats detected";
+          statusDiv.classList.add("result-scanner-negative");
+          statusDiv.innerHTML = "no threats detected!";
         }
       };
       eventSource.onerror = (e) => {

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -166,10 +166,10 @@ jobs.controller("UploadJobsCtrl", [
     });
 
     // this needs to be a function due to the stateful `jobItem`
-    ctrl.jobImages = () => ctrl.jobs.map((jobItem) => jobItem.image);
+    ctrl.jobImages = () => ctrl.jobs.map(jobItem => jobItem.image);
 
     ctrl.removeJob = (job) => {
-      const index = ctrl.jobs.findIndex((j) => j.name === job.name);
+      const index = ctrl.jobs.findIndex(j => j.name === job.name);
 
       if (index > -1) {
         ctrl.jobs.splice(index, 1);
@@ -202,26 +202,24 @@ jobs.controller("UploadJobsCtrl", [
       }
     );
 
-    $scope.$on("$destroy", function () {
+    $scope.$on('$destroy', function () {
       freeImageDeleteListener();
       freeImageDeleteFailListener();
     });
-  },
-]);
+  }]);
 
-jobs.directive("uiUploadJobs", [
-  function () {
+jobs.directive('uiUploadJobs', [ function () {
     return {
-      restrict: "E",
+      restrict: 'E',
       scope: {
         // Annoying that we can't make a uni-directional binding
         // as we don't really want to modify the original
-        jobs: "=",
+        jobs: '='
       },
-      controller: "UploadJobsCtrl",
-      controllerAs: "ctrl",
+      controller: 'UploadJobsCtrl',
+      controllerAs: 'ctrl',
       bindToController: true,
-      template: template,
+      template: template
     };
   },
 ]);

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -21,7 +21,6 @@ jobs.controller('UploadJobsCtrl', [
     '$scope',
     '$window',
     'apiPoll',
-    'mediaApi',
     'imageService',
     'labelService',
     'presetLabelService',
@@ -32,7 +31,6 @@ jobs.controller('UploadJobsCtrl', [
             $window,
             apiPoll,
             imageService,
-            mediaApi,
             labelService,
             presetLabelService,
             editsService) {
@@ -61,21 +59,19 @@ jobs.controller('UploadJobsCtrl', [
 //      console.log(event.data)
 //    }
 
+   if (window.EventSource) {
+     console.log("connecting to SSE..............")
+     var stringSource = new EventSource("https://api.media.example.com/sse");
+     stringSource.addEventListener('message', function(e) {
+        console.log(e.data)
+     });
+    } else {
+     console.log("Sorry. This browser doesn't seem to support Server sent event");
+    }
+
     ctrl.jobs.forEach(jobItem => {
         jobItem.status = 'uploading';
-        console.log(jobItem)
 
-        console.log("*********document.cookie*************")
-        console.log(document.cookie)
-       if (window.EventSource) {
-         console.log("connecting to SSE..............")
-         var stringSource = new EventSource("https://api.media.example.com/sse");
-         stringSource.addEventListener('message', function(e) {
-            console.log(e.data)
-         });
-        } else {
-         console.log("Sorry. This browser doesn't seem to support Server sent event");
-        }
         jobItem.resourcePromise.then(resource => {
             jobItem.status = 'indexing';
             jobItem.resource = resource;

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -21,6 +21,7 @@ jobs.controller('UploadJobsCtrl', [
     '$scope',
     '$window',
     'apiPoll',
+    'mediaApi',
     'imageService',
     'labelService',
     'presetLabelService',
@@ -31,19 +32,50 @@ jobs.controller('UploadJobsCtrl', [
             $window,
             apiPoll,
             imageService,
+            mediaApi,
             labelService,
             presetLabelService,
             editsService) {
 
+
+
     var ctrl = this;
     const presetLabels = presetLabelService.getLabels();
 
-    // State machine-esque async transitions
     const eventName = 'Image upload';
+
+
+//    console.log('Contect to WS******************')
+
+//    let sockets3 = new WebSocket("ws://localhost:9001/socket")
+//
+//
+//    sockets3.onopen = (event) => {
+//    console.log("Conected3...")
+//    console.log(event)
+//    sockets3.send("some msg")
+//    }
+//
+//    sockets3.onmessage = (event) => {
+//      console.log("OnMessage Event")
+//      console.log(event.data)
+//    }
 
     ctrl.jobs.forEach(jobItem => {
         jobItem.status = 'uploading';
+        console.log(jobItem)
 
+        console.log("*********document.cookie*************")
+        console.log(document.cookie)
+       if (window.EventSource) {
+         console.log("connecting to SSE..............")
+         var stringSource = new EventSource("https://api.media.example.com/sse");
+         stringSource.addEventListener('message', function(e) {
+            console.log(e.data)
+         });
+        } else {
+         console.log("Sorry. This browser doesn't seem to support Server sent event");
+        }
         jobItem.resourcePromise.then(resource => {
             jobItem.status = 'indexing';
             jobItem.resource = resource;

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -54,5 +54,13 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val elasticSearchHealthCheck = new ElasticSearchHealthCheck(controllerComponents, elasticSearch)
   val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi, buildInfo)
 
+  val metrics = new MediaApiMetrics(config)
+  val virusStatusSqsMessageConsumer = new VirusStatusSqsMessageConsumer(config, metrics)
+
+  virusStatusSqsMessageConsumer.startSchedule()
+  context.lifecycle.addStopHook {
+    () => virusStatusSqsMessageConsumer.actorSystem.terminate()
+  }
+
   override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController)
 }

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -54,13 +54,14 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val elasticSearchHealthCheck = new ElasticSearchHealthCheck(controllerComponents, elasticSearch)
   val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi, buildInfo)
 
+
   val metrics = new MediaApiMetrics(config)
   val virusStatusSqsMessageConsumer = new VirusStatusSqsMessageConsumer(config, metrics)
+  val notificationController = new NotificationController(auth, virusStatusSqsMessageConsumer, controllerComponents)
 
-  virusStatusSqsMessageConsumer.startSchedule()
   context.lifecycle.addStopHook {
     () => virusStatusSqsMessageConsumer.actorSystem.terminate()
   }
 
-  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController)
+  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController, notificationController)
 }

--- a/media-api/app/controllers/NotificationController.scala
+++ b/media-api/app/controllers/NotificationController.scala
@@ -1,29 +1,20 @@
 package controllers
 
 import play.api.mvc._
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.stream.ActorMaterializer
 import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.auth.Authentication.PandaUser
 import lib.VirusStatusSqsMessageConsumer
-import play.api.http.ContentTypes
-import play.api.libs.EventSource
-import play.api.libs.json.JsValue
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.duration._
-import scala.concurrent.Future
+class NotificationController(auth: Authentication, consumer: VirusStatusSqsMessageConsumer, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext) extends  BaseController {
 
-class NotificationController(auth: Authentication, consumer: VirusStatusSqsMessageConsumer, override val controllerComponents: ControllerComponents) extends  BaseController {
-  implicit val system = ActorSystem("NotificationSystem")
-  implicit val materializer = ActorMaterializer()
 
-  def serverSentEvent(userEmail: String) = Action {
-    Ok.chunked(notificationSource(userEmail) via EventSource.flow).as(ContentTypes.EVENT_STREAM)
-  }
+  def getScannerStatus = auth.async { request =>
 
-  def notificationSource(user: String): Source[JsValue, _] = {
-    val tickSource = Source.tick(0.millis, 100.millis, "TICK")
-    tickSource.map(_ => consumer.getNotificationMsg(user) )
+    val user =  request.user match {
+      case user: PandaUser => Some(user.user.email.toLowerCase())
+      case _ => None
+    }
+    Future(Ok(consumer.getNotificationMsg(user.getOrElse(""))))
   }
 }

--- a/media-api/app/controllers/NotificationController.scala
+++ b/media-api/app/controllers/NotificationController.scala
@@ -1,0 +1,34 @@
+package controllers
+
+import play.api.mvc._
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import akka.stream.ActorMaterializer
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.PandaUser
+import lib.VirusStatusSqsMessageConsumer
+import play.api.http.ContentTypes
+import play.api.libs.EventSource
+import play.api.libs.json.JsValue
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+class NotificationController(auth: Authentication, consumer: VirusStatusSqsMessageConsumer, override val controllerComponents: ControllerComponents) extends  BaseController {
+  implicit val system = ActorSystem("NotificationSystem")
+  implicit val materializer = ActorMaterializer()
+
+  def serverSentEvent = auth.async { request =>
+  val user =  request.user match {
+      case user: PandaUser => Some(user.user.email.toLowerCase())
+      case _ => None
+    }
+    Future.successful(Ok.chunked(notificationSource(user) via EventSource.flow).as(ContentTypes.EVENT_STREAM))
+  }
+
+  def notificationSource(user: Option[String]): Source[JsValue, _] = {
+    val tickSource = Source.tick(0.millis, 100.millis, "TICK")
+    val s = tickSource.map(_ => consumer.getNotificationMsg(user) )
+    s
+  }
+}

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -39,6 +39,8 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   lazy val imageBucket: String = properties("s3.image.bucket")
   lazy val thumbBucket: String = properties("s3.thumb.bucket")
 
+  val scannerSqsQueueUrl = properties("scanner.sqs.queue.url")
+
   lazy val cloudFrontPrivateKeyLocation: String = "/etc/gu/ssl/private/cloudfront.pem"
 
   lazy val cloudFrontDomainImageBucket: Option[String] = properties.get("cloudfront.domain.imagebucket")

--- a/media-api/app/lib/MediaApiMetrics.scala
+++ b/media-api/app/lib/MediaApiMetrics.scala
@@ -7,6 +7,7 @@ import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${config.stage}/MediaApi", config) {
 
   val searchQueries = new TimeMetric("ElasticSearch")
+  val sqsMessage = new CountMetric("SNSMessage")
 
   def searchTypeDimension(value: String): Dimension =
     new Dimension().withName("SearchType").withValue(value)

--- a/media-api/app/lib/MediaApiMetrics.scala
+++ b/media-api/app/lib/MediaApiMetrics.scala
@@ -7,7 +7,7 @@ import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${config.stage}/MediaApi", config) {
 
   val searchQueries = new TimeMetric("ElasticSearch")
-  val sqsMessage = new CountMetric("SNSMessage")
+  val sqsMessage = new CountMetric("SQSMessage")
 
   def searchTypeDimension(value: String): Dimension =
     new Dimension().withName("SearchType").withValue(value)

--- a/media-api/app/lib/VirusStatusSqsMessageConsumer.scala
+++ b/media-api/app/lib/VirusStatusSqsMessageConsumer.scala
@@ -15,15 +15,15 @@ class VirusStatusSqsMessageConsumer(config: MediaApiConfig, mediaApiMetrics: Med
     }
 
 
-  def getNotificationMsg(user: Option[String]): JsValue = {
+  def getNotificationMsg(user: String): JsValue = {
     val snsMessage = getMessages(waitTime = 20, maxMessages = 1).head
     val msg  = extractSNSMessage(snsMessage)
     val notification = msg match {
-      case Some(msg) => println((msg.body \ "metadata" \ "uploaded_by").as[String]);msg.body;
+      case Some(msg) => msg.body
       case None => Json.obj("uploadedBy" -> "None")
     }
     val uploadedBy = (notification \ "metadata" \ "uploaded_by").as[String]
-    if(uploadedBy == user.get){
+    if(uploadedBy == user){
       deleteMessage(snsMessage)
       notification
     } else {

--- a/media-api/app/lib/VirusStatusSqsMessageConsumer.scala
+++ b/media-api/app/lib/VirusStatusSqsMessageConsumer.scala
@@ -16,14 +16,18 @@ class VirusStatusSqsMessageConsumer(config: MediaApiConfig, mediaApiMetrics: Med
 
 
   def getNotificationMsg(user: Option[String]): JsValue = {
-    val messages = getMessages(waitTime = 20, maxMessages = 1)
-    messages.map{ message =>
-      val msg  = extractSNSMessage(message)
-      println(s"Message: $msg")
-      msg match {
-        case Some(msg) => msg.body
-        case None => Json.obj("uploadedBy" -> "None")
-      }
-    }.filter(m => (m \ "uploadedBy").as[String] == user.get).head
+    val snsMessage = getMessages(waitTime = 20, maxMessages = 1).head
+    val msg  = extractSNSMessage(snsMessage)
+    val notification = msg match {
+      case Some(msg) => println((msg.body \ "metadata" \ "uploaded_by").as[String]);msg.body;
+      case None => Json.obj("uploadedBy" -> "None")
+    }
+    val uploadedBy = (notification \ "metadata" \ "uploaded_by").as[String]
+    if(uploadedBy == user.get){
+      deleteMessage(snsMessage)
+      notification
+    } else {
+      Json.obj("scan_result" -> "scanning")
+    }
   }
 }

--- a/media-api/app/lib/VirusStatusSqsMessageConsumer.scala
+++ b/media-api/app/lib/VirusStatusSqsMessageConsumer.scala
@@ -1,0 +1,25 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.SqsMessageConsumer
+import play.api.libs.json._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class VirusStatusSqsMessageConsumer(config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics) extends SqsMessageConsumer(
+  config.scannerSqsQueueUrl, config, mediaApiMetrics.sqsMessage) {
+
+  override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] =
+    PartialFunction.condOpt(subject) {
+      case "SLING_SCANNER_RESULT_NEGATIVE" => processNegativeImage
+      case "SLING_SCANNER_RESULT_POSITIVE" => processPositiveImage
+    }
+
+  def processNegativeImage(message: JsValue) = Future {
+    // emit to UI with negative status
+  }
+
+  def processPositiveImage(message: JsValue) = Future {
+    // emit to UI with positive status
+  }
+}

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -40,5 +40,5 @@ GET     /management/imageCounts                       com.gu.mediaservice.lib.ma
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.ManagementWithPermissions.disallowRobots
 
-#SSE
-GET   /sse/:userEmail                       controllers.NotificationController.serverSentEvent(userEmail: String)
+#Scanner status
+GET     /scanner/status                               controllers.NotificationController.getScannerStatus

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -41,4 +41,4 @@ GET     /management/imageCounts                       com.gu.mediaservice.lib.ma
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.ManagementWithPermissions.disallowRobots
 
 #SSE
-GET   /sse                       controllers.NotificationController.serverSentEvent
+GET   /sse/:userEmail                       controllers.NotificationController.serverSentEvent(userEmail: String)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -39,3 +39,6 @@ GET     /management/imageCounts                       com.gu.mediaservice.lib.ma
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.ManagementWithPermissions.disallowRobots
+
+#SSE
+GET   /sse                       controllers.NotificationController.serverSentEvent


### PR DESCRIPTION
## What does this change?

- Consume messages from SQS queue that published to SNS scanner topic
- Add a streaming endpoint reading from sqs consumer
- handle SSE connection and scanner notification in UI

## How can success be measured?


## Screenshots (if applicable)
![Screenshot from 2020-12-09 01-30-13](https://user-images.githubusercontent.com/33189781/101554252-f0b69880-39be-11eb-9ec9-ad6028a5863e.png)
![Screenshot from 2020-12-09 01-32-02](https://user-images.githubusercontent.com/33189781/101554257-f1e7c580-39be-11eb-9367-578d966ba27c.png)
![Screenshot from 2020-12-09 01-34-11](https://user-images.githubusercontent.com/33189781/101554260-f2805c00-39be-11eb-91de-5fbfb01e7278.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
