### PR TITLE
Handle empty sqs scanner  queue

### DIFF
--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -39,7 +39,7 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   lazy val imageBucket: String = properties("s3.image.bucket")
   lazy val thumbBucket: String = properties("s3.thumb.bucket")
 
-  val scannerSqsQueueUrl = properties("scanner.sqs.queue.url")
+  lazy val scannerSqsQueueUrl = properties("scanner.sqs.queue.url")
 
   lazy val cloudFrontPrivateKeyLocation: String = "/etc/gu/ssl/private/cloudfront.pem"
 


### PR DESCRIPTION
## What does this change?
Handle empty SQS scanner queue
Fix Media-Api configuration

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
