### PR TITLE
Some suggestions for the BBC metadata work

### DIFF
--- a/admin-tools/dev/app/AdminToolsComponents.scala
+++ b/admin-tools/dev/app/AdminToolsComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.config.GridConfigResources
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.AdminToolsCtr
 import lib.AdminToolsConfig
@@ -6,8 +7,8 @@ import play.api.Configuration
 import router.Routes
 
 object AdminToolsComponents {
-  def config(configuration: Configuration) = new AdminToolsConfig(
-    configuration ++ Configuration.from(Map(
+  def config(resources: GridConfigResources) = new AdminToolsConfig(
+    resources.configuration ++ Configuration.from(Map(
       "domain.root" -> "local.dev-gutools.co.uk",
       "auth.keystore.bucket" -> "not-used",
       "thrall.kinesis.stream.name"-> "not-used",

--- a/auth/app/auth/AuthConfig.scala
+++ b/auth/app/auth/AuthConfig.scala
@@ -1,11 +1,8 @@
 package auth
 
-import com.gu.mediaservice.lib.config.CommonConfig
-import play.api.Configuration
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 
-import scala.concurrent.ExecutionContext
-
-class AuthConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class AuthConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val rootUri: String = services.authBaseUri
   val mediaApiUri: String = services.apiBaseUri
   val kahunaUri = services.kahunaBaseUri

--- a/collections/app/lib/CollectionsConfig.scala
+++ b/collections/app/lib/CollectionsConfig.scala
@@ -1,12 +1,9 @@
 package lib
 
-import com.gu.mediaservice.lib.config.CommonConfig
-import play.api.Configuration
-
-import scala.concurrent.ExecutionContext
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 
 
-class CollectionsConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class CollectionsConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val collectionsTable = string("dynamo.table.collections")
   val imageCollectionsTable = string("dynamo.table.imageCollections")
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/BBCImageProcessorConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/BBCImageProcessorConfig.scala
@@ -1,8 +1,7 @@
 package com.gu.mediaservice.lib.bbc
 
-import com.gu.mediaservice.lib.config.CommonConfig
 import play.api.Configuration
 
-class BBCImageProcessorConfig(config: Configuration) extends CommonConfig(config) {
-  val configBucket = string("s3.config.bucket")
+class BBCImageProcessorConfig(config: Configuration) {
+  val configBucket: String = config.get[String]("s3.config.bucket")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/BBCMetadataProcessor.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/BBCMetadataProcessor.scala
@@ -1,9 +1,9 @@
 package com.gu.mediaservice.lib.bbc
 
 import com.gu.mediaservice.lib.bbc.components.BBCImageProcessorsDependencies
-import com.gu.mediaservice.lib.cleanup.{ImageProcessor, MetadataCleaners}
+import com.gu.mediaservice.lib.cleanup.{ImageProcessor, ImageProcessorResources, MetadataCleaners}
+import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.model.Image
-import play.api.Configuration
 
 /*
 BBC Metadata processor.
@@ -14,9 +14,9 @@ image.processors = [
   ...
 ]
 */
-class BBCMetadataProcessor(configuration: Configuration) extends ImageProcessor {
+class BBCMetadataProcessor(resources: ImageProcessorResources) extends ImageProcessor {
 
-  val metadataStore = BBCImageProcessorsDependencies.metadataStore(configuration)
+  val metadataStore = BBCImageProcessorsDependencies.metadataStore(resources)
 
   override def apply(image: Image): Image = {
       val metadataConfig = metadataStore.get

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/BBCSupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/BBCSupplierProcessors.scala
@@ -1,8 +1,8 @@
 package com.gu.mediaservice.lib.bbc
 
 import com.gu.mediaservice.lib.bbc.components.BBCImageProcessorsDependencies
-import com.gu.mediaservice.lib.cleanup.{AapParser, ActionImagesParser, AlamyParser, AllStarParser, ApParser, ComposeImageProcessors, CorbisParser, EpaParser, GettyCreditParser, GettyXmpParser, ImageProcessor, PaParser, PhotographerParser, ReutersParser, RexParser, RonaldGrantParser}
-import com.gu.mediaservice.lib.config.KnownPhotographer
+import com.gu.mediaservice.lib.cleanup.{AapParser, ActionImagesParser, AlamyParser, AllStarParser, ApParser, ComposeImageProcessors, CorbisParser, EpaParser, GettyCreditParser, GettyXmpParser, ImageProcessor, ImageProcessorResources, PaParser, PhotographerParser, ReutersParser, RexParser, RonaldGrantParser}
+import com.gu.mediaservice.lib.config.{CommonConfig, KnownPhotographer}
 import com.gu.mediaservice.lib.config.PhotographersList.caseInsensitiveLookup
 import com.gu.mediaservice.model.{ContractPhotographer, Image, Photographer, StaffPhotographer}
 import play.api.Configuration
@@ -34,10 +34,10 @@ object BBCSupplierProcessors extends ComposeImageProcessors(
   RonaldGrantParser
 )
 
-class BBCPhotographerParser(configuration: Configuration) extends ImageProcessor {
+class BBCPhotographerParser(resources: ImageProcessorResources) extends ImageProcessor {
 
   import com.gu.mediaservice.lib.bbc.components.BBCMetadataConfig.companyPhotographersMap
-  val metadataStore = BBCImageProcessorsDependencies.metadataStore(configuration)
+  val metadataStore = BBCImageProcessorsDependencies.metadataStore(resources)
   lazy val staffPhotographersBBC = metadataStore.get.staffPhotographers
   lazy val contractedPhotographersBBC = metadataStore.get.contractedPhotographersMap
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/components/BBCImageProcessorsDependencies.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/components/BBCImageProcessorsDependencies.scala
@@ -1,6 +1,8 @@
 package com.gu.mediaservice.lib.bbc.components
 
 import com.gu.mediaservice.lib.bbc.BBCImageProcessorConfig
+import com.gu.mediaservice.lib.cleanup.ImageProcessorResources
+import com.gu.mediaservice.lib.config.CommonConfig
 import play.api.Configuration
 
 import scala.collection.mutable
@@ -25,19 +27,19 @@ object BBCImageProcessorsDependencies {
   /*
   * The laziness here guarantees that the metadataStore will be only loaded if a BBC processor is instantiated.
   * */
-  lazy val metadataStore: Configuration => MetadataStore = memoizeOnce { configuration =>
-    val bbcImageProcessorConfig = new BBCImageProcessorConfig(configuration)
+  lazy val metadataStore: ImageProcessorResources => MetadataStore = memoizeOnce { resources =>
+    val bbcImageProcessorConfig = new BBCImageProcessorConfig(resources.commonConfiguration.configuration)
     val bucket = bbcImageProcessorConfig.configBucket
-    val metadataStore = new MetadataStore(bucket, bbcImageProcessorConfig)
-    metadataStore.update()
+    val metadataStore = new MetadataStore(bucket, resources.commonConfiguration)
+    metadataStore.scheduleUpdates(resources.actorSystem.scheduler)
     metadataStore
   }
 
-  lazy val usageRightsStore: Configuration => BBCUsageRightsStore = memoizeOnce { configuration =>
-    val bbcImageProcessorConfig = new BBCImageProcessorConfig(configuration)
+  lazy val usageRightsStore: ImageProcessorResources => BBCUsageRightsStore = memoizeOnce { resources =>
+    val bbcImageProcessorConfig = new BBCImageProcessorConfig(resources.commonConfiguration.configuration)
     val bucket = bbcImageProcessorConfig.configBucket
-    val usageRightsStore = new BBCUsageRightsStore(bucket, bbcImageProcessorConfig)
-    usageRightsStore.update()
+    val usageRightsStore = new BBCUsageRightsStore(bucket, resources.commonConfiguration)
+    usageRightsStore.scheduleUpdates(resources.actorSystem.scheduler)
     usageRightsStore
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ImageProcessorResources.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ImageProcessorResources.scala
@@ -1,0 +1,14 @@
+package com.gu.mediaservice.lib.cleanup
+
+import akka.actor.ActorSystem
+import com.gu.mediaservice.lib.config.CommonConfig
+import play.api.Configuration
+
+/**
+  * Resources that can be injected into a dynamically loaded ImageProcessor
+  */
+trait ImageProcessorResources {
+  def processorConfiguration: Configuration
+  def commonConfiguration: CommonConfig
+  def actorSystem: ActorSystem
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigResources.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigResources.scala
@@ -1,0 +1,6 @@
+package com.gu.mediaservice.lib.config
+
+import akka.actor.ActorSystem
+import play.api.Configuration
+
+case class GridConfigResources(configuration: Configuration, actorSystem: ActorSystem)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ImageProcessorLoader.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ImageProcessorLoader.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.config
 
-import com.gu.mediaservice.lib.cleanup.ImageProcessor
+import akka.actor.ActorSystem
+import com.gu.mediaservice.lib.cleanup.{ImageProcessor, ImageProcessorResources}
 import com.typesafe.config.ConfigException.BadValue
 import com.typesafe.config.{Config, ConfigObject, ConfigOrigin, ConfigValue, ConfigValueType}
 import com.typesafe.scalalogging.StrictLogging
@@ -12,31 +13,36 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 object ImageProcessorLoader extends StrictLogging {
-  case class ImageProcessorConfigDetails(className: String, config: Option[Configuration], moduleConfiguration: Configuration, origin: ConfigOrigin, path: String)
+  case class ImageProcessorConfigDetails(className: String,
+                                         config: Option[Configuration],
+                                         commonConfiguration: CommonConfig,
+                                         actorSystem: ActorSystem,
+                                         origin: ConfigOrigin,
+                                         path: String)
 
-  def imageProcessorsConfigLoader(moduleConfiguration: Configuration): ConfigLoader[Seq[ImageProcessor]] = (config: Config, path: String) => {
+  def imageProcessorsConfigLoader(commonConfiguration: CommonConfig, actorSystem: ActorSystem): ConfigLoader[Seq[ImageProcessor]] = (config: Config, path: String) => {
     config
       .getList(path)
       .iterator()
       .asScala.map { configValue =>
-      parseConfigValue(configValue, path, moduleConfiguration)
+      parseConfigValue(configValue, path, commonConfiguration, actorSystem)
     }.map(loadImageProcessor).toList
   }
 
-  def imageProcessorConfigLoader(moduleConfiguration: Configuration): ConfigLoader[ImageProcessor] = (config: Config, path: String) => {
-    val configDetails = parseConfigValue(config.getValue(path), path, moduleConfiguration)
+  def imageProcessorConfigLoader(commonConfiguration: CommonConfig, actorSystem: ActorSystem): ConfigLoader[ImageProcessor] = (config: Config, path: String) => {
+    val configDetails = parseConfigValue(config.getValue(path), path, commonConfiguration, actorSystem)
     loadImageProcessor(configDetails)
   }
 
-  private def parseConfigValue(configValue: ConfigValue, path: String, moduleConfiguration: Configuration): ImageProcessorConfigDetails = {
+  private def parseConfigValue(configValue: ConfigValue, path: String, commonConfiguration: CommonConfig, actorSystem: ActorSystem): ImageProcessorConfigDetails = {
     configValue match {
       case plainClass if plainClass.valueType == ConfigValueType.STRING =>
-        ImageProcessorConfigDetails(plainClass.unwrapped.asInstanceOf[String], None, moduleConfiguration,plainClass.origin, path)
+        ImageProcessorConfigDetails(plainClass.unwrapped.asInstanceOf[String], None, commonConfiguration, actorSystem, plainClass.origin, path)
       case withConfig:ConfigObject if validConfigObject(withConfig) =>
         val config = withConfig.toConfig
         val className = config.getString("className")
         val processorConfig = config.getConfig("config")
-        ImageProcessorConfigDetails(className, Some(Configuration(processorConfig)), moduleConfiguration, withConfig.origin, path)
+        ImageProcessorConfigDetails(className, Some(Configuration(processorConfig)), commonConfiguration, actorSystem, withConfig.origin, path)
       case _ =>
         throw new BadValue(configValue.origin, path, s"An image processor can either a class name (string) or object with className (string) and config (object) fields. This ${configValue.valueType} is not valid.")
     }
@@ -48,8 +54,13 @@ object ImageProcessorLoader extends StrictLogging {
   }
 
   private def loadImageProcessor(details: ImageProcessorConfigDetails): ImageProcessor = {
+    val config = new ImageProcessorResources {
+      override def processorConfiguration: Configuration = details.config.getOrElse(Configuration.empty)
+      override def commonConfiguration: CommonConfig = details.commonConfiguration
+      override def actorSystem: ActorSystem = ???
+    }
     ImageProcessorLoader
-      .loadImageProcessor(details.className, details.config.getOrElse(details.moduleConfiguration))
+      .loadImageProcessor(details.className, config)
       .getOrElse { error =>
         val configError = s"Unable to instantiate image processor from config: $error"
         logger.error(configError)
@@ -57,7 +68,7 @@ object ImageProcessorLoader extends StrictLogging {
       }
   }
 
-  def loadImageProcessor(className: String, config: Configuration): Either[String, ImageProcessor] = {
+  def loadImageProcessor(className: String, config: ImageProcessorResources): Either[String, ImageProcessor] = {
     for {
       imageProcessorClass <- loadClass(className)
       imageProcessorInstance <- instantiate(imageProcessorClass, config)
@@ -71,17 +82,24 @@ object ImageProcessorLoader extends StrictLogging {
       s"Unknown error whilst loading $className, check logs"
   }
 
-  private def instantiate(imageProcessorClass: Class[_], config: Configuration): Either[String, ImageProcessor] = {
-
+  private def instantiate(imageProcessorClass: Class[_], resources: ImageProcessorResources): Either[String, ImageProcessor] = {
+    // Fail fast if processor config is provided but the specified image processor doesn't take any resources
+    def assertNoConfiguration[T](ok: Right[String, T]): Either[String, T] = {
+      if (resources.processorConfiguration.keys.nonEmpty) {
+        Left(s"Attempt to initialise image processor ${imageProcessorClass.getCanonicalName} failed as configuration is provided but the constructor does not take configuration as an argument.")
+      } else {
+        ok
+      }
+    }
 
     val maybeCompanionObject = Try(imageProcessorClass.getField("MODULE$").get(imageProcessorClass)).toOption
     val maybeNoArgCtor = Try(imageProcessorClass.getDeclaredConstructor()).toOption
-    val maybeConfigCtor = Try(imageProcessorClass.getDeclaredConstructor(classOf[Configuration])).toOption
+    val maybeConfigCtor = Try(imageProcessorClass.getDeclaredConstructor(classOf[ImageProcessorResources])).toOption
     for {
       instance <- (maybeCompanionObject, maybeNoArgCtor, maybeConfigCtor) match {
-        case (Some(companionObject), _, _) => Right(companionObject)
-        case (_, _, Some(configCtor)) => Right(configCtor.newInstance(config))
-        case (_, Some(noArgCtor), None) => Right(noArgCtor.newInstance())
+        case (Some(companionObject), _, _) => assertNoConfiguration(Right(companionObject))
+        case (_, _, Some(configCtor)) => Right(configCtor.newInstance(resources))
+        case (_, Some(noArgCtor), None) => assertNoConfiguration(Right(noArgCtor.newInstance()))
         case (None, None, None) => Left(s"Unable to find a suitable constructor for ${imageProcessorClass.getCanonicalName}. Must either have a no arg constructor or a constructor taking one argument of type ImageProcessorConfig.")
       }
       castInstance <- try {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -1,7 +1,8 @@
 package com.gu.mediaservice.lib.play
 
+import akka.actor.ActorSystem
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import com.gu.mediaservice.lib.logging.{GridLogging, LogConfig}
 import com.gu.mediaservice.lib.management.{BuildInfo, Management}
 import play.api.ApplicationLoader.Context
@@ -15,10 +16,10 @@ import play.filters.gzip.GzipFilterComponents
 
 import scala.concurrent.ExecutionContext
 
-abstract class GridComponents[Config <: CommonConfig](context: Context, val loadConfig: Configuration => Config) extends BuiltInComponentsFromContext(context)
+abstract class GridComponents[Config <: CommonConfig](context: Context, val loadConfig: GridConfigResources => Config) extends BuiltInComponentsFromContext(context)
   with AhcWSComponents with HttpFiltersComponents with CORSComponents with GzipFilterComponents {
   // first of all create the config for the service
-  val config: Config = loadConfig(configuration)
+  val config: Config = loadConfig(GridConfigResources(configuration, actorSystem))
   // next thing is to set up log shipping
   LogConfig.initKinesisLogging(config)
   LogConfig.initLocalLogShipping(config)

--- a/cropper/app/lib/CropperConfig.scala
+++ b/cropper/app/lib/CropperConfig.scala
@@ -1,12 +1,11 @@
 package lib
 
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
+
 import java.io.File
 
-import com.gu.mediaservice.lib.config.CommonConfig
-import play.api.Configuration
 
-
-class CropperConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class CropperConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val imgPublishingBucket = string("publishing.image.bucket")
 
   val imgPublishingHost = string("publishing.image.host")

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -1,14 +1,12 @@
 package lib
 
 import java.io.File
-
 import com.gu.mediaservice.lib.cleanup.{ComposedImageProcessor, ImageProcessor}
-import com.gu.mediaservice.lib.config.{CommonConfig, ImageProcessorLoader}
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources, ImageProcessorLoader}
 import com.gu.mediaservice.model._
 import com.typesafe.scalalogging.StrictLogging
-import play.api.Configuration
 
-class ImageLoaderConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) with StrictLogging {
+class ImageLoaderConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) with StrictLogging {
   val imageBucket: String = string("s3.image.bucket")
 
   val thumbnailBucket: String = string("s3.thumb.bucket")
@@ -53,8 +51,9 @@ class ImageLoaderConfig(playAppConfiguration: Configuration) extends CommonConfi
     * If a configuration is needed by is not provided by the config, the module configuration will be used instead.
     */
   val imageProcessor: ComposedImageProcessor = {
+    val configLoader = ImageProcessorLoader.imageProcessorsConfigLoader(this, resources.actorSystem)
     val processors = configuration
-      .get[Seq[ImageProcessor]]("image.processors")(ImageProcessorLoader.imageProcessorsConfigLoader(configuration))
+      .get[Seq[ImageProcessor]]("image.processors")(configLoader)
     ImageProcessor.compose("ImageConfigLoader-imageProcessor", processors:_*)
   }
 }

--- a/image-loader/test/scala/lib/ImageProcessorLoaderTest.scala
+++ b/image-loader/test/scala/lib/ImageProcessorLoaderTest.scala
@@ -1,7 +1,8 @@
 package scala.lib
 
-import com.gu.mediaservice.lib.cleanup.ImageProcessor
-import com.gu.mediaservice.lib.config.ImageProcessorLoader
+import akka.actor.ActorSystem
+import com.gu.mediaservice.lib.cleanup.{ImageProcessor, ImageProcessorResources}
+import com.gu.mediaservice.lib.config.{CommonConfig, ImageProcessorLoader}
 import com.gu.mediaservice.model.Image
 import com.typesafe.config.ConfigException.BadValue
 import com.typesafe.config.ConfigFactory
@@ -18,8 +19,8 @@ class NoArgImageProcessor extends ImageProcessor {
   override def apply(image: Image): Image = image.copy(id = "no-arg-image-processed")
 }
 
-case class ConfigImageProcessor(config: Configuration) extends ImageProcessor {
-  override def apply(image: Image): Image = image.copy(id = s"config-image-processed ${config.hashCode}")
+case class ConfigImageProcessor(resources: ImageProcessorResources) extends ImageProcessor {
+  override def apply(image: Image): Image = image.copy(id = s"config-image-processed ${resources.hashCode}")
 }
 
 class NotAnImageProcessor {
@@ -31,49 +32,79 @@ class ImageProcessorWithStringConstructor(configString: String) extends ImagePro
 }
 
 class ImageProcessorLoaderTest extends FreeSpec with Matchers with EitherValues {
+  val akkaActorSystem: ActorSystem = ActorSystem("test")
   val testImage: Image = Image("image", DateTime.now(), "Test", None, Map.empty, null, null, null, null, null, null, null, null, null, null)
   val testConfig: Configuration = Configuration.empty
   val testNonEmptyConfig: Configuration = Configuration.from(Map("someConfig" -> "my value"))
 
-  implicit val imageProcessorsConfigLoader = ImageProcessorLoader.imageProcessorsConfigLoader(testConfig)
-  implicit val imageProcessorConfigLoader = ImageProcessorLoader.imageProcessorConfigLoader(testConfig)
+  val commonConfiguration: Configuration = Configuration.from(Map(
+    "grid.stage" -> "DEV",
+    "grid.appName" -> "image-loader",
+    "auth.keystore.bucket" -> "not-used-in-test",
+    "thrall.kinesis.stream.name" -> "not-used-in-test",
+    "thrall.kinesis.lowPriorityStream.name" -> "not-used-in-test",
+    "domain.root" -> "not.used.in.test.com"
+  ))
+  val commonConfig: CommonConfig = new CommonConfig(commonConfiguration) {
+
+  }
+  def resources(processorConfig: Configuration) = new ImageProcessorResources {
+    override def processorConfiguration: Configuration = processorConfig
+    override def commonConfiguration: CommonConfig = commonConfig
+    override def actorSystem: ActorSystem = akkaActorSystem
+  }
 
   "The class reflector" - {
     "should successfully load a no arg ImageProcessor instance" in {
-      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NoArgImageProcessor].getCanonicalName, testConfig)
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NoArgImageProcessor].getCanonicalName, resources(testConfig))
       instance.right.value.apply(testImage).id shouldBe "no-arg-image-processed"
     }
 
     "should successfully load a config arg ImageProcessor instance" in {
-      val instance = ImageProcessorLoader.loadImageProcessor(classOf[ConfigImageProcessor].getCanonicalName, testConfig)
-      instance.right.value.apply(testImage).id shouldBe s"config-image-processed ${testConfig.hashCode}"
+      val resources1 = resources(testConfig)
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[ConfigImageProcessor].getCanonicalName, resources1)
+      instance.right.value.apply(testImage).id shouldBe s"config-image-processed ${resources1.hashCode}"
     }
 
     "should successfully load a companion object ImageProcessor" in {
-      val instance = ImageProcessorLoader.loadImageProcessor(ObjectImageProcessor.getClass.getCanonicalName, testConfig)
+      val instance = ImageProcessorLoader.loadImageProcessor(ObjectImageProcessor.getClass.getCanonicalName, resources(testConfig))
       instance.right.value.apply(testImage).id shouldBe s"object-image-processed"
     }
 
     "should fail to load something that isn't an ImageProcessor" in {
-      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NotAnImageProcessor].getCanonicalName, testConfig)
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NotAnImageProcessor].getCanonicalName, resources(testConfig))
       instance.left.value shouldBe "Failed to cast scala.lib.NotAnImageProcessor to an ImageProcessor"
     }
 
     "should fail to load something that doesn't have a suitable constructor" in {
-      val instance = ImageProcessorLoader.loadImageProcessor(classOf[ImageProcessorWithStringConstructor].getCanonicalName, testConfig)
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[ImageProcessorWithStringConstructor].getCanonicalName, resources(testConfig))
       instance.left.value shouldBe "Unable to find a suitable constructor for scala.lib.ImageProcessorWithStringConstructor. Must either have a no arg constructor or a constructor taking one argument of type ImageProcessorConfig."
     }
 
     "should fail to load something that doesn't exist" in {
-      val instance = ImageProcessorLoader.loadImageProcessor("scala.lib.ImageProcessorThatDoesntExist", testConfig)
+      val instance = ImageProcessorLoader.loadImageProcessor("scala.lib.ImageProcessorThatDoesntExist", resources(testConfig))
       instance.left.value shouldBe "Unable to find image processor class scala.lib.ImageProcessorThatDoesntExist"
     }
-    
+
+    "should fail to load a no arg processor that doesn't take configuration with non-empty configuration" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NoArgImageProcessor].getCanonicalName, resources(testNonEmptyConfig))
+      instance.left.value shouldBe "Attempt to initialise image processor scala.lib.NoArgImageProcessor failed as configuration is provided but the constructor does not take configuration as an argument."
+    }
+
+    "should fail to load an object processor that doesn't take configuration with non-empty configuration" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(ObjectImageProcessor.getClass.getCanonicalName, resources(testNonEmptyConfig))
+      instance.left.value shouldBe "Attempt to initialise image processor scala.lib.ObjectImageProcessor$ failed as configuration is provided but the constructor does not take configuration as an argument."
+    }
+
   }
 
   import ImageProcessorLoader._
 
   "The config loader" - {
+
+
+    implicit val imageProcessorsConfigLoader = ImageProcessorLoader.imageProcessorsConfigLoader(commonConfig, akkaActorSystem)
+    implicit val imageProcessorConfigLoader = ImageProcessorLoader.imageProcessorConfigLoader(commonConfig, akkaActorSystem)
 
     "should load an image processor from a classname" in {
       val conf:Configuration = Configuration.from(Map(
@@ -98,7 +129,7 @@ class ImageProcessorLoaderTest extends FreeSpec with Matchers with EitherValues 
       val processors = conf.get[Seq[ImageProcessor]]("some.path")
       val processor = processors.head
       inside(processor) {
-        case ConfigImageProcessor(config) => config.get[String]("parameter") shouldBe "value"
+        case ConfigImageProcessor(config) => config.processorConfiguration.get[String]("parameter") shouldBe "value"
       }
     }
 
@@ -139,8 +170,23 @@ class ImageProcessorLoaderTest extends FreeSpec with Matchers with EitherValues 
       }
     }
 
+    "should fail to load multiple image processors if they don't meet the spec" in {
+      val conf:Configuration = Configuration.from(Map(
+        "some.path" -> List(
+          "scala.lib.NoArgImageProcessor",
+          Map(
+            "noClassName" -> "scala.lib.ConfigImageProcessor",
+            "config" -> Map("parameter" -> "value")
+          )
+        )
+      ))
+      val thrown = the[BadValue] thrownBy {
+        conf.get[Seq[ImageProcessor]]("some.path")
+      }
+      thrown.getMessage should include ("An image processor can either a class name (string) or object with className (string) and config (object) fields. This OBJECT is not valid.")
+    }
 
-    "should fail to an image processors it isn't a string" in {
+    "should fail to load an image processors if the config isn't a string" in {
       val conf:Configuration = Configuration.from(Map(
         "some.path" -> List(
           List("fred")

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -1,9 +1,8 @@
 package lib
 
-import com.gu.mediaservice.lib.config.CommonConfig
-import play.api.Configuration
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 
-class KahunaConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val rootUri: String = services.kahunaBaseUri
   val mediaApiUri: String = services.apiBaseUri
   val authUri: String = services.authBaseUri

--- a/leases/app/lib/LeasesConfig.scala
+++ b/leases/app/lib/LeasesConfig.scala
@@ -1,14 +1,12 @@
 package lib
 
-import java.net.URI
-
 import com.gu.mediaservice.lib.argo.model.Link
-import com.gu.mediaservice.lib.config.CommonConfig
-import play.api.Configuration
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 
+import java.net.URI
 import scala.util.Try
 
-class LeasesConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class LeasesConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val leasesTable = string("dynamo.tablename.leasesTable")
 
   val rootUri: String = services.leasesBaseUri

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -1,8 +1,7 @@
 package lib
 
-import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import org.joda.time.DateTime
-import play.api.Configuration
 
 import scala.util.Try
 
@@ -11,7 +10,7 @@ case class StoreConfig(
   storeKey: String
 )
 
-class MediaApiConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class MediaApiConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val configBucket: String = string("s3.config.bucket")
   val usageMailBucket: String = string("s3.usagemail.bucket")
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch
 
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
+import com.gu.mediaservice.lib.config.{GridConfigLoader, GridConfigResources}
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchConfig, ElasticSearchExecutions}
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
@@ -49,12 +50,13 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
     "grid.appName"
   )
 
-  private val mediaApiConfig = new MediaApiConfig(
+  private val mediaApiConfig = new MediaApiConfig(GridConfigResources(
     Configuration.from(Map(
       "es6.shards" -> 0,
       "es6.replicas" -> 0
-    ) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap)
-  )
+    ) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap),
+    null
+  ))
 
   private val mediaApiMetrics = new MediaApiMetrics(mediaApiConfig)
   val elasticConfig = ElasticSearchConfig(alias = "readalias", url = es6TestUrl,

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -1,11 +1,10 @@
 package lib
 
 import com.amazonaws.regions.{Region, RegionUtils}
-import com.gu.mediaservice.lib.config.CommonConfig
-import play.api.Configuration
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 
 
-class EditsConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class EditsConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val dynamoRegion: Region = RegionUtils.getRegion(string("aws.region"))
 
   val collectionsBucket: String = string("s3.collections.bucket")

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -3,10 +3,9 @@ package lib
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.gu.mediaservice.lib.aws.AwsClientBuilderUtils
-import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
-import play.api.Configuration
 
 case class KinesisReceiverConfig(
   override val awsRegion: String,
@@ -29,7 +28,7 @@ object KinesisReceiverConfig {
   )
 }
 
-class ThrallConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class ThrallConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val imageBucket: String = string("s3.image.bucket")
 
   val writeAlias: String = string("es.index.aliases.write")

--- a/usage/app/lib/UsageConfig.scala
+++ b/usage/app/lib/UsageConfig.scala
@@ -2,17 +2,16 @@ package lib
 
 import com.amazonaws.regions.{Region, RegionUtils}
 import com.amazonaws.services.identitymanagement._
-import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.lib.net.URI.ensureSecure
-import play.api.{Configuration, Logger}
 
 import scala.util.Try
 
 
 case class KinesisReaderConfig(streamName: String, arn: String, appName: String)
 
-class UsageConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) with GridLogging {
+class UsageConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) with GridLogging {
   val rootUri: String = services.metadataBaseUri
   val kahunaUri: String = services.kahunaBaseUri
   val usageUri: String = services.usageBaseUri


### PR DESCRIPTION
Some suggestions in response to https://github.com/guardian/grid/pull/3069

Including:
 - Makes an actor system available to processors so that updates can be scheduled for stores.
 - Rationalises the way the processor local and application/module config is passed through
 - This is done by introducing a `ImageProcessorResources` type that includes the processor config, the common config and the actor system for injection into dynamically loaded processors
 - Making the play actor system available in the config classes so it can be injected for the above
 - Reintroducing some tests that were removed
 - Reintroducing an assertion to help prevent misconfiguration

Caveats:
 - the implementation of ImageProcessorResources is not a case class so doesn't support comparable and thus probably isn't suitable to use in a map (i.e. won't work for argument based memoisation).
 - This passes tests but is untested code