### PR TITLE
Override login/logout URIs

### DIFF
--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -23,7 +23,7 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
     val indexLinks = List(
       Link("root",          config.mediaApiUri),
       Link("login",         config.services.loginUriTemplate),
-      Link("ui:logout",     s"${config.rootUri}/logout"),
+      Link("ui:logout",     config.services.logoutUri.getOrElse(s"${config.rootUri}/logout")),
       Link("session",       s"${config.rootUri}/session")
     )
     respond(indexData, indexLinks)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -58,7 +58,9 @@ abstract class CommonConfig(val configuration: Configuration) extends AwsClientB
     stringDefault("hosts.usagePrefix", s"$rootAppName-usage."),
     stringDefault("hosts.collectionsPrefix", s"$rootAppName-collections."),
     stringDefault("hosts.leasesPrefix", s"$rootAppName-leases."),
-    stringDefault("hosts.authPrefix", s"$rootAppName-auth.")
+    stringDefault("hosts.authPrefix", s"$rootAppName-auth."),
+    stringOpt("app.loginURI"),
+    stringOpt("app.logoutURI")
   )
 
   val corsAllowedOrigins: Set[String] = getStringSet("security.cors.allowedOrigins")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -11,7 +11,9 @@ case class ServiceHosts(
   usagePrefix: String,
   collectionsPrefix: String,
   leasesPrefix: String,
-  authPrefix: String
+  authPrefix: String,
+  loginURI: Option[String],
+  logoutURI: Option[String]
 )
 
 object ServiceHosts {
@@ -31,7 +33,9 @@ object ServiceHosts {
       usagePrefix = s"$rootAppName-usage.",
       collectionsPrefix = s"$rootAppName-collections.",
       leasesPrefix = s"$rootAppName-leases.",
-      authPrefix = s"$rootAppName-auth."
+      authPrefix = s"$rootAppName-auth.",
+      None,
+      None
     )
   }
 }
@@ -65,7 +69,9 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
 
   val corsAllowedDomains: Set[String] = corsAllowedOrigins.map(baseUri)
 
-  val loginUriTemplate = s"$authBaseUri/login{?redirectUri}"
+  val loginUriTemplate = hosts.loginURI.getOrElse(s"$authBaseUri/login{?redirectUri}")
+
+  val logoutUri = hosts.logoutURI
 
   def baseUri(host: String) = s"https://$host"
 }


### PR DESCRIPTION
## What does this change?

It adds the possibility to override the defaults URI for login and logout.

## How can success be measured?

Test the new configurations: "app.loginURI" and "app.logoutURI" should redirected to those links when login/logout

## Who should look at this?

@wainaina @adrielulanovsky 

## Tested?
- [x] locally
- [ ] on TEST
