### PR TITLE
Upload status integrity

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -9,6 +9,7 @@ import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.logging.{FALLBACK, GridLogging, LogMarker, RequestLoggingContext}
 import com.gu.mediaservice.lib.{DateTimeUtils, ImageIngestOperations}
 import com.gu.mediaservice.model.UnsupportedMimeTypeException
+import com.gu.scanamo.error.ConditionNotMet
 import lib.FailureResponse.Response
 import lib.{FailureResponse, _}
 import lib.imaging.{NoSuchImageExistsInS3, UserImageLoaderException}
@@ -212,6 +213,7 @@ class ImageLoaderController(auth: Authentication,
         }
         uploadStatusTable.updateStatus(digestedFile.digest, status).flatMap{status =>
           status match {
+            case Left(_: ConditionNotMet) => logger.info(s"no image upload status to update for image ${digestedFile.digest}")
             case Left(error) => logger.error(s"an error occurred while updating image upload status, image-id:${digestedFile.digest}, error:${error}")
             case Right(_) => logger.info(s"image upload status updated successfully, image-id: ${digestedFile.digest}")
           }

--- a/image-loader/app/controllers/UploadStatusController.scala
+++ b/image-loader/app/controllers/UploadStatusController.scala
@@ -3,7 +3,7 @@ package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth._
-import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.error.{ConditionNotMet, DynamoReadError, ScanamoError}
 import lib._
 import model.{StatusType, UploadStatus}
 import play.api.mvc._
@@ -40,7 +40,8 @@ class UploadStatusController(auth: Authentication,
           .updateStatus(imageId, uploadStatus)
           .map{
             case Right(record) => respond(UploadStatus(record.status, record.errorMessage))
-            case Left(error: DynamoReadError) => respondError(BadRequest, "cannot-update", s"Cannot update upload status ${error}")
+            case Left(_: ConditionNotMet) => respondError(BadRequest, "cannot-update", s"Cannot update as no upload status for $imageId exists")
+            case Left(error: ScanamoError) => respondError(BadRequest, "cannot-update", s"Cannot update upload status ${error}")
           }
     }
   }

--- a/image-loader/app/lib/UploadStatusTable.scala
+++ b/image-loader/app/lib/UploadStatusTable.scala
@@ -2,10 +2,12 @@ package lib
 
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.scanamo._
+import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.syntax._
 import model.{UploadStatus, UploadStatusRecord}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class UploadStatusTable(config: ImageLoaderConfig) extends DynamoDB(config, config.uploadStatusTable) {
 
@@ -24,9 +26,13 @@ class UploadStatusTable(config: ImageLoaderConfig) extends DynamoDB(config, conf
       case Some(error) => set('status -> updateRequest.status) and set('errorMessages -> error)
       case None => set('status -> updateRequest.status)
     }
-    ScanamoAsync.exec(client)(uploadStatusTable.update(
-      'id -> imageId,
-      expression = updateExpression
-    ))
+    ScanamoAsync.exec(client)(
+      uploadStatusTable
+        .given(attributeExists('id))
+        .update(
+          'id -> imageId,
+          update = updateExpression
+        )
+    )
   }
 }

--- a/image-loader/app/model/UploadStatus.scala
+++ b/image-loader/app/model/UploadStatus.scala
@@ -5,8 +5,8 @@ import play.api.libs.json._
 case class UploadStatusRecord(
                                id: String,
                                fileName: Option[String],
-                               uploadedBy: Option[String],
-                               uploadTime: Option[String],
+                               uploadedBy: String,
+                               uploadTime: String,
                                identifiers: Option[String],
                                status: StatusType,
                                errorMessage: Option[String],

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -287,8 +287,7 @@ class Uploader(val store: ImageLoaderStore,
                                  (implicit logMarker: LogMarker) = store.store(storableOptimisedImage)
 
   def loadFile(digestedFile: DigestedFile,
-               user: Principal,
-               uploadedBy: Option[String],
+               uploadedBy: String,
                identifiers: Option[String],
                uploadTime: DateTime,
                filename: Option[String],
@@ -312,7 +311,7 @@ class Uploader(val store: ImageLoaderStore,
           tempFile = tempFile,
           mimeType = Some(mimeType),
           uploadTime = uploadTime,
-          uploadedBy = uploadedBy.getOrElse(Authentication.getIdentity(user)),
+          uploadedBy = uploadedBy,
           identifiers = identifiersMap,
           uploadInfo = UploadInfo(filename)
         )


### PR DESCRIPTION
## What does this change?
Two key changes here:
 1. When an attempt is made to update the status of a record that doesn't exist we fail rather than inserting a partial record
 2. We try harder to collect information about who uploaded the image and the time they uploaded it.