### PR TITLE
Can search for searchable metadata via server.

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -7,6 +7,10 @@ export const querySuggestions = angular.module('querySuggestions', [
     mediaApi.name
 ]);
 
+const fieldAliases = window._clientConfig.fieldAliases.
+                                  filter(entry => entry.displaySearchHint === true).
+                                  map(entry => entry.alias);
+
 // FIXME: get fields and subjects from API
 export const filterFields = [
     'by',
@@ -38,7 +42,8 @@ export const filterFields = [
     'filename',
     'photoshoot',
     'leasedBy',
-    'is'
+    'is',
+    ... fieldAliases
 ].sort();
 // TODO: add date fields
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -47,7 +47,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   val searchFilters = new SearchFilters(config)
   val syndicationFilter = new SyndicationFilter(config)
 
-  val queryBuilder = new QueryBuilder(matchFields, overQuotaAgencies)
+  val queryBuilder = new QueryBuilder(matchFields, overQuotaAgencies, config)
 
   def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] =
     getImageWithSourceById(id).map(_.map(_.instance))

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -11,7 +11,16 @@ import com.sksamuel.elastic4s.requests.common.Operator
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{MultiMatchQuery, MultiMatchQueryBuilderType}
 import lib.querysyntax._
-class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agency]) extends ImageFields with GridLogging {
+import lib.MediaApiConfig
+
+class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agency], config: MediaApiConfig) extends ImageFields with GridLogging {
+
+  def resolveFieldPath(field: String): String = {
+    config.fieldAliasConfigs.find(_.alias == field) match {
+      case Some(x) => x.elasticsearchPath
+      case None => getFieldPath(field)
+    }
+  }
 
   // For some sad reason, there was no helpful alias for this in the ES library
   private def multiMatchPhraseQuery(value: String, fields: Seq[String]): MultiMatchQuery =
@@ -31,17 +40,17 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
       // Force AND operator else it will only require *any* of the words, not *all*
-      case Words(value) => matchQuery(getFieldPath(field), value).operator(Operator.AND)
-      case Phrase(value) => matchPhraseQuery(getFieldPath(field), value)
-      case DateRange(start, end) => rangeQuery(getFieldPath(field)).gte(printDateTime(start)).lte(printDateTime(end))
+      case Words(value) => matchQuery(resolveFieldPath(field), value).operator(Operator.AND)
+      case Phrase(value) => matchPhraseQuery(resolveFieldPath(field), value)
+      case DateRange(start, end) => rangeQuery(resolveFieldPath(field)).gte(printDateTime(start)).lte(printDateTime(end))
       case e => throw InvalidQuery(s"Cannot do single field query on $e")
     }
     case HierarchyField => condition.value match {
-      case Phrase(value) => termQuery(getFieldPath("pathHierarchy"), value)
+      case Phrase(value) => termQuery(resolveFieldPath("pathHierarchy"), value)
       case _ => throw InvalidQuery("Cannot accept non-Phrase value for HierarchyField Match")
     }
     case HasField => condition.value match {
-      case HasValue(value) => boolQuery().filter(existsQuery(getFieldPath(value)))
+      case HasValue(value) => boolQuery().filter(existsQuery(resolveFieldPath(value)))
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {


### PR DESCRIPTION
## What does this change?

In the search bar, a user should be able to enter an organization/admin enabled file metadata alias and only images matching that metadata field are displayed: <property>:<value>.
Additionally, a user should be able to select any of the additional field aliases where the displaySearchHint is true from the advanced filter by pressing +, select a hint, type in search value and be able to view only images matching the search parameters.

## How can success be measured?

By ensuring searching for images with their file metadata alias returns appropriate result.

## Screenshots (if applicable)

<img width="347" alt="110196813-547a2180-7e47-11eb-9811-64803c85ebb9" src="https://user-images.githubusercontent.com/6728165/111136136-b2141980-857d-11eb-989e-e847cf00b1ac.png">
<img width="678" alt="110196811-5348f480-7e47-11eb-94c3-97debacc844e" src="https://user-images.githubusercontent.com/6728165/111136143-b3dddd00-857d-11eb-80c8-4bfda5edbcf7.png">
<img width="656" alt="110196809-50e69a80-7e47-11eb-9a79-ca658dc043ab" src="https://user-images.githubusercontent.com/6728165/111136144-b4767380-857d-11eb-9ff2-60fa6ec4ff0c.png">

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [Y] locally
- [ ] on TEST
