### PR TITLE
add undelete button in Image Thumbnail

### DIFF
--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
@@ -24,13 +24,11 @@ archiver.controller('ArchiverCtrl',
     ctrl.unarchive = unarchive;
     ctrl.archiving = false;
     ctrl.canUndelete = false;
-    ctrl.isDeleted = false;
 
     ctrl.undelete = undelete;
 
     mediaApi.getSession().then(session => {
         if (ctrl.image.data.softDeletedMetadata !== undefined && (session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy)) { ctrl.canUndelete = true; }
-        if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
     });
 
     mediaApi.canUserArchive().then(canArchive => {
@@ -74,6 +72,7 @@ archiver.directive('grArchiverStatus', [function() {
         controllerAs: 'ctrl',
         scope: {
             image: '=',
+            isDeleted: '=',
             readonly: '='
         },
         bindToController: true,

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -78,9 +78,18 @@
                    <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
                 </a>
             </div>
+            <a ng-if="ctrl.canUndelete && ctrl.isDeleted"
+               type="button"
+               class="gr-archiver-status__button inner-clickable  gr-archiver-status--archived"
+               title="Undelete"
+               ng-click="ctrl.undelete()">
+                <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
+            </a>
 
-            <gr-archiver-status class="result-editor__archiver"
-                                image="ctrl.image">
+
+            <gr-archiver-status ng-if="!ctrl.isDeleted" class="result-editor__archiver"
+                                image="ctrl.image"
+                                isDeleted="ctrl.isDeleted">
             </gr-archiver-status>
         </div>
 


### PR DESCRIPTION
## What does this change?

Add Undelete button in Image Thumbnail in the upload page

## How can success be measured?
when re-uploading an image that is soft-deleted, an error message should appear says the Image already exists and has been soft deleted
and permissioned users are able to undelete that image through undelete button in the image thumbnail

## Screenshots (if applicable)

![Screenshot from 2021-11-01 10-42-12](https://user-images.githubusercontent.com/33189781/139646191-dcbcf4f4-5e5c-4e5c-a64f-c3bcf50f13f7.png)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
